### PR TITLE
add GeoData integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+GeoData = "9b6fcbb8-86d6-11e9-1ce7-23a6bb139a78"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 HTTP = "0.8, 0.9"
-ZipFile = "0.9"
+GeoData = "^0.3.3"
 URIs = "1"
+ZipFile = "0.9"
 julia = "^1.5"

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -1,9 +1,10 @@
 module RasterDataSources
 
 using Dates,
+      GeoData,
       HTTP,
-      ZipFile,
-      URIs
+      URIs,
+      ZipFile
 
 abstract type RasterDataSource end
 abstract type RasterDataSet end
@@ -18,7 +19,11 @@ export WorldClim, CHELSA, EarthEnv, AWAP, ALWB
 
 export BioClim, Climate, Weather, LandCover, HabitatHeterogeneity
 
+export Values, Deciles
+
 export getraster
+
+export geoarray, stack, series
 
 include("shared.jl")
 include("worldclim/shared.jl")

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -1,42 +1,47 @@
-resolutions(::Type{EarthEnv{HabitatHeterogeneity}}) = (1, 5, 25)
+resolutions(::Type{EarthEnv{HabitatHeterogeneity}}) = ("1km", "5km", "25km")
+defres(::Type{EarthEnv{HabitatHeterogeneity}}) = "25km"
 layers(::Type{EarthEnv{HabitatHeterogeneity}}) = 
     (:cv, :evenness, :range, :shannon, :simpson, :std, :Contrast, :Correlation, 
      :Dissimilarity, :Entropy, :Homogeneity, :Maximum, :Uniformity, :Variance)
 
 """
-    getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, [layer::Integer]; resolution::Int=25) => String
+    getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, [layer::Integer]; res::Int=25) => String
+    getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Integer, res::Int=25) => String
 
 Download EarthEnv habitat heterogeneity data, choosing layers from: 
-$(layers(EarthEnv{HabitatHeterogeneity})) and resolution from 
+$(layers(EarthEnv{HabitatHeterogeneity})) and res from 
 $(resolutions(EarthEnv{HabitatHeterogeneity})).
 
 Without a layer argument, all layers will be getrastered and a tuple of paths returned. 
 If the data is already getrastered the path will be returned without the getraster.
 """
-function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol; resolution=25)
+function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol; res::String=defres(T))
+    getraster(T, layer, res)
+end
+function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol, res::String)
     _check_layer(T, layer)
-    _check_resolution(T, resolution)
-    path = rasterpath(T, layer; resolution)
-    url = rasterurl(T, layer; resolution) 
+    _check_res(T, res)
+    path = rasterpath(T, layer; res)
+    url = rasterurl(T, layer; res) 
     return _maybe_download(url, path)
 end
 
-rastername(::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol; resolution::Integer=25) =
-    "$(layer)_$(resolution)km.tif"
-rasterpath(T::Type{<:EarthEnv{HabitatHeterogeneity}}, layer::Symbol; resolution::Integer=25) =
-    joinpath(rasterpath(T), string(resolution) * "km", rastername(T, layer; resolution))
-rasterurl(T::Type{EarthEnv{HabitatHeterogeneity}}, layer; resolution::Integer=25) =
-    joinpath(rasterurl(T), "$(resolution)km/$(layer)_01_05_$(resolution)km_$(_getprecision(layer, resolution)).tif")
+rastername(::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol; res::String=defres(T)) =
+    "$(layer)_$(res).tif"
+rasterpath(T::Type{<:EarthEnv{HabitatHeterogeneity}}, layer::Symbol; res::String=defres(T)) =
+    joinpath(rasterpath(T), string(res), rastername(T, layer; res))
+rasterurl(T::Type{EarthEnv{HabitatHeterogeneity}}, layer; res::String=defres(T)) =
+    joinpath(rasterurl(T), "$(res)/$(layer)_01_05_$(res)_$(_getprecision(layer, res)).tif")
 
 _pathsegment(::Type{HabitatHeterogeneity}) = "habitat_heterogeneity"
 
-function _getprecision(layer, resolution)
+function _getprecision(layer, res)
     precision = "uint16"
     # WELLCOME TO HELL
-    precision = ((resolution == 10) && (layer == :cv)) ? "uint32" : precision
+    precision = ((res == 10) && (layer == :cv)) ? "uint32" : precision
     precision = (layer == :Contrast) ? "uint32" : precision
     precision = (layer == :Dissimilarity) ? "uint32" : precision
     precision = (layer == :Variance) ? "uint32" : precision
-    precision = ((resolution == 25) && (layer == :Entropy)) ? "uint32" : precision
+    precision = ((res == 25) && (layer == :Entropy)) ? "uint32" : precision
     # /HELL
 end

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -2,6 +2,7 @@ layers(::Type{EarthEnv{LandCover}}) = 1:12
 
 """
     getraster(T::Type{EarthEnv{LandCover}}, [layer::Integer]; discover::Bool=false) => String
+    getraster(T::Type{EarthEnv{LandCover}}, layer::Integer, discover::Bool) => String
 
 Download EarthEnv landcover data, choosing layers from: $(layers(EarthEnv{LandCover})).
 
@@ -9,6 +10,9 @@ Without a layer argument, all layers will be getrastered and a tuple of paths re
 If the data is already getrastered the path will be returned.
 """
 function getraster(T::Type{EarthEnv{LandCover}}, layer::Integer; discover::Bool=false)
+    getraster(T, layer, discover)
+end
+function getraster(T::Type{EarthEnv{LandCover}}, layer::Integer, discover::Bool)
     _check_layer(T, layer)
     url = rasterurl(T, layer; discover)
     path = rasterpath(T, layer; discover)

--- a/src/geodata.jl
+++ b/src/geodata.jl
@@ -1,0 +1,139 @@
+const GD = GeoData
+
+"""
+    geoarray(T::Type{<:RasterDataSource}, args...; kw...)
+
+Load a `RasterDataSource` as an `AbstractGeoStack`. `T`, `args` are
+are passed to `getraster`, while `kw` args are for both `getraster` and
+`AbstractGeoStack`.
+"""
+function geoarray end
+"""
+    stack(T::Type{<:RasterDataSource}, args...; kw...)
+
+Load a `RasterDataSource` as an `AbstractGeoStack`. `T`, `args` are
+are passed to `getraster`, while `kw` args are for both `getraster` and
+`AbstractGeoStack`.
+"""
+function stack end
+"""
+    series(T::Type{<:RasterDataSource}, args...; kw...)
+
+Load a `RasterDataSource` as an `AbstractGeoSeries`. `T`, `args` are
+are passed to `getraster`, while `kw` args are for both `getraster` and
+`AbstractGeoSeries`.
+"""
+function series end
+
+### WorldClim ###
+
+# Weather
+function geoarray(T::Type{<:WorldClim{Weather}}, layer::Symbol; date, kw...)
+    GDALarray(getraster(T, layer; date=date); kw...)
+end
+function stack(T::Type{WorldClim{Weather}}, layers=layers(T); date, kw...)
+    GDALstack(map(l -> getraster(T, l; date=date), layers); keys=layers, kw...)
+end
+function series(T::Type{WorldClim{Weather}}, layers=layers(T); date, window=(), kw...)
+    step = Month(1)
+    dates = _date_sequence(date, step)
+    timedim = Ti(dates; mode=Sampled(Ordered(), Regular(step), Intervals(Start())))
+    stacks = [stack(T, layers; date=d, window=window) for d in dates]
+    GeoData.GeoSeries(stacks, timedim; kw...)
+end
+
+# Climate
+function geoarray(T::Type{<:WorldClim{Climate}}, layer::Symbol; month, res=defres(T), kw...)
+    GDALarray(getraster(T, layer; res=res, month=month); kw...)
+end
+function stack(T::Type{WorldClim{Climate}}, layers=layers(T); month, res=defres(T), kw...)
+    filenames = map(l -> getraster(T, l; res=res, month=month), layers)
+    GDALstack(filenames; keys=layers, kw...)
+end
+function series(T::Type{WorldClim{Climate}}, layers=layers(T);
+    res=defres(T), month=1:12, window=(), kw...
+)
+    timedim = Ti(month; mode=Sampled(span=Regular(1), sampling=Intervals(Start())))
+    stacks = [stack(T, layers; res=res, month=m, window=window) for m in month]
+    GeoData.GeoSeries(stacks, timedim; kw...)
+end
+
+# BioClim
+function geoarray(T::Type{<:WorldClim{BioClim}}, layer::Int; res=defres(T), kw...)
+    GDALarray(getraster(T, layer; res=res); kw...)
+end
+function stack(T::Type{WorldClim{BioClim}}, layers=layers(T); res=defres(T), kw...)
+    filenames = [getraster(T, l; res=res) for l in layers]
+    GDALstack(filenames; keys=_asbioclim(layers), kw...)
+end
+
+_asbioclim(ns) = map(_asbioclim, ns)
+_asbioclim(n::Int) = string("BIO", n)
+
+#### CHELSA ####
+
+# BioClim
+function geoarray(T::Type{<:CHELSA{BioClim}}, layer::Int; kw...)
+    GDALarray(getraster(T, layer); kw...)
+end
+function stack(T::Type{CHELSA{BioClim}}, layers=layers(T); kw...)
+    filenames = [getraster(T, l) for l in layers]
+    GDALstack(filenames; keys=_asbioclim(layers), kw...)
+end
+
+#### EarthEnv ####
+
+# HabitatHeterogeneity
+function geoarray(T::Type{<:EarthEnv{HabitatHeterogeneity}}, layer::Symbol; res=defres(T), kw...)
+    GDALarray(getraster(T, layer; res=res); kw...)
+end
+function stack(T::Type{EarthEnv{HabitatHeterogeneity}}, layers=layers(T); res=defres(T), kw...)
+    filenames = [getraster(T, l; res=res) for l in layers]
+    GDALstack(filenames; keys=layers, kw...)
+end
+
+# LandCover
+function geoarray(T::Type{<:EarthEnv{LandCover}}, layer::Int; discover=false, kw...)
+    GDALarray(getraster(T, layer; discover=discover); kw...)
+end
+function stack(T::Type{EarthEnv{LandCover}}, layers=layers(T); discover=false, kw...)
+    filenames = [getraster(T, l; discover=discover) for l in layers]
+    GDALstack(filenames; keys=layers, kw...)
+end
+
+#### ALWB ####
+
+function geoarray(T::Type{<:ALWB}, layer::Symbol; date::TimeType, kw...)
+    NCDarray(getraster(T, layer; date=date), layer; kw...)
+end
+function stack(T::Type{<:ALWB}, layers=layers(T); date, kw...)
+    filenames = [getraster(T, l; date=date) for l in layers]
+    NCDstack(filenames; keys=layers, kw...)
+end
+function series(T::Type{<:ALWB{M,P}}, layers=layers(T); date, window=(), kw...) where {M,P}
+    step = P(1)
+    dates = _date_sequence(date, step)
+    timedim = Ti(dates; mode=Sampled(span=Regular(step), sampling=Intervals(Start())))
+    stacks = [stack(T, layers; date=d, window=window) for d in dates]
+    GeoData.GeoSeries(stacks, timedim; kw...)
+end
+
+#### AWAP ####
+
+# AWAP asciii files don't have crs and BOM don't specify what it is besides
+# being evenly spaced lat/lon. So we assume it's EPSG(4326) and set it manually
+function geoarray(T::Type{AWAP}, layer; date, kw...)
+    GDALarray(getraster(T, layer; date=date); crs=EPSG(4326), kw...)
+end
+function stack(T::Type{AWAP}, layers=layers(T); date, kw...)
+    GDALstack(map(l -> getraster(T, l; date=date), layers);
+        childkwargs=(crs=EPSG(4326),), keys=layers, kw...
+    )
+end
+function series(T::Type{AWAP}, layers=layers(T); date, window=(), kw...)
+    step = Day(1)
+    dates = _date_sequence(date, step)
+    timedim = Ti(dates; mode=Sampled(span=Regular(step), sampling=Intervals(Start())))
+    stacks = [stack(T, layers; date=d, window=window) for d in dates]
+    GeoData.GeoSeries(stacks, timedim; kw...)
+end

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -1,8 +1,8 @@
 
-function getraster(T::Type{<:RasterDataSource}, layers::Tuple=layers(T); kw...)
+function getraster(T::Type{<:RasterDataSource}, layers::Tuple=layers(T), args...; kw...)
     map(layers) do l
         _check_layer(T, l)
-        getraster(T, l; kw...)
+        getraster(T, l, args...; kw...)
     end
 end
 
@@ -32,11 +32,7 @@ function delete_rasters(T::Type)
     ispath(rasterpath(T)) && rm(rasterpath(T))
 end
 
-function delete_rasters(::Type{TS}, ::Type{TD}) where {TS <: RasterDataSource, TD <: RasterDataSet}
-    ispath(_raster_assets_folder(TS, TD)) && rm(_raster_assets_folder(TS, TD); recursive=false)
-end
-
-_check_resolution(T, res) =
+_check_res(T, res) =
     res in resolutions(T) || throw(ArgumentError("Resolution $res not in $(resolutions(T))"))
 _check_layer(T, layer) =
     layer in layers(T) || throw(ArgumentError("Layer $layer not in $(layers(T))"))
@@ -45,6 +41,6 @@ _date2string(t, date) = Dates.format(date, _dateformat(t))
 _string2date(t, d::AbstractString) = Date(d, _dateformat(t))
 
 _date_sequence(dates::AbstractArray, step) = dates
-_date_sequence(dates::Tuple, step) = first(dates):step:last(dates)
+_date_sequence(dates::NTuple{2}, step) = first(dates):step:last(dates)
 _date_sequence(date, step) = date:step:date
 

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -1,25 +1,29 @@
 layers(::Type{WorldClim{BioClim}}) = 1:19
 
 """
-    getraster(T::Type{WorldClim{BioClim}}, [layer::Integer]; resolution::String="10m") => String
+    getraster(T::Type{WorldClim{BioClim}}, [layer::Integer]; res::String="10m") => String
+    getraster(T::Type{WorldClim{BioClim}}, layer::Integer, res::String)
 
 Download WorldClim weather data, choosing `layer` from $(layers(WorldClim{BioClim})),
-and `resolution` from $(resolutions(WorldClim{BioClim})).
+and `res` from $(resolutions(WorldClim{BioClim})).
 
 Without a layer argument, all layers will be getrastered, and a tuple of paths is returned. 
 If the data is already getrastered the path will be returned.
 """
-function getraster(T::Type{WorldClim{BioClim}}, layer::Integer; resolution::String="10m")
+function getraster(T::Type{WorldClim{BioClim}}, layer::Integer; res::String=defres(T))
+    getraster(T, layer, res)
+end
+function getraster(T::Type{WorldClim{BioClim}}, layer::Integer, res::String)
     _check_layer(T, layer)
-    _check_resolution(T, resolution)
+    _check_res(T, res)
 
-    raster_path = rasterpath(T, layer; resolution)
-    zip_path = zippath(T, layer; resolution)
+    raster_path = rasterpath(T, layer; res)
+    zip_path = zippath(T, layer; res)
 
     if !isfile(raster_path)
-        _maybe_download(zipurl(T, layer; resolution), zip_path)
+        _maybe_download(zipurl(T, layer; res), zip_path)
         mkpath(dirname(raster_path))
-        raster_name = rastername(T, layer; resolution)
+        raster_name = rastername(T, layer; res)
         zf = ZipFile.Reader(zip_path)
         write(raster_path, read(_zipfile_to_read(raster_name, zf)))
         close(zf)
@@ -30,9 +34,9 @@ end
 # BioClim layers don't get their own folder
 rasterpath(T::Type{<:WorldClim{BioClim}}, layer; kw...) =
     joinpath(rasterpath(T), rastername(T, layer; kw...))
-rastername(T::Type{<:WorldClim{BioClim}}, key; resolution) = "wc2.1_$(resolution)_bio_$key.tif"
-zipname(T::Type{<:WorldClim{BioClim}}, key; resolution) = "wc2.1_$(resolution)_bio.zip"
-zipurl(T::Type{<:WorldClim{BioClim}}, key; resolution) =
-    joinpath(WORLDCLIM_URI, "base", zipname(T, key; resolution))
-zippath(T::Type{<:WorldClim{BioClim}}, key; resolution) =
-    joinpath(rasterpath(T), "zips", zipname(T, key; resolution))
+rastername(T::Type{<:WorldClim{BioClim}}, key; res) = "wc2.1_$(res)_bio_$key.tif"
+zipname(T::Type{<:WorldClim{BioClim}}, key; res) = "wc2.1_$(res)_bio.zip"
+zipurl(T::Type{<:WorldClim{BioClim}}, key; res) =
+    joinpath(WORLDCLIM_URI, "base", zipname(T, key; res))
+zippath(T::Type{<:WorldClim{BioClim}}, key; res) =
+    joinpath(rasterpath(T), "zips", zipname(T, key; res))

--- a/src/worldclim/climate.jl
+++ b/src/worldclim/climate.jl
@@ -1,52 +1,52 @@
 layers(::Type{WorldClim{Climate}}) = (:tmin, :tmax, :tave, :prec, :srad, :wind, :vapr)
 
 """
-    getraster(T::Type{WorldClim{Climate}}, [layer::Symbol]; resolution::String="10m", month=1:12) => Vector{String}
+    getraster(T::Type{WorldClim{Climate}}, [layer]; res::String="10m", month=1:12) => Vector{String}
+    getraster(T::Type{WorldClim{Climate}}, layer, month, res)
 
 Download WorldClim weather data, choosing `layer` from $(layers(WorldClim{Climate})),
-and `resolution` from $(resolutions(WorldClim{Climate})), and months from `1:12`.
+and `res` from $(resolutions(WorldClim{Climate})), and months from `1:12`.
 
 Without a layer argument, all layers will be getrastered, and a tuple of paths is returned. 
 By default all months are getrastered, but can also be getrastered individually.
 If the data is already getrastered the path will be returned.
 """
-function getraster(T::Type{WorldClim{Climate}}, layer; resolution::String="10m", month=1:12)
-    _getraster(T, layer, resolution, month)
+function getraster(T::Type{WorldClim{Climate}}, layer; month=1:12, res::String=defres(T))
+    getraster(T, layer, month, res)
 end
-
-function _getraster(T::Type{WorldClim{Climate}}, layers, resolution, months)
-    map(l -> _getraster(T, l, resolution, months), layers)
+function getraster(T::Type{WorldClim{Climate}}, layers, months, res::String)
+    map(l -> getraster(T, l, months, res), layers)
 end
-function _getraster(T::Type{WorldClim{Climate}}, layer::Symbol, resolution, months)
-    map(m -> _getraster(T, layer, resolution, m), months)
-end
-function _getraster(T::Type{WorldClim{Climate}}, layer::Symbol, resolution, month::Integer)
+function getraster(T::Type{WorldClim{Climate}}, layer::Symbol, month::Integer, res::String)
     _check_layer(T, layer)
-    _check_resolution(T, resolution)
-    raster_path = rasterpath(T, layer; resolution, month)
+    _check_res(T, res)
+    raster_path = rasterpath(T, layer; res, month)
     if !isfile(raster_path)
-        zip_path = zippath(T, layer; resolution, month)
-        _maybe_download(zipurl(T, layer; resolution, month), zip_path)
+        zip_path = zippath(T, layer; res, month)
+        _maybe_download(zipurl(T, layer; res, month), zip_path)
         zf = ZipFile.Reader(zip_path)
         mkpath(dirname(raster_path))
-        raster_name = rastername(T, layer; resolution, month)
+        raster_name = rastername(T, layer; res, month)
         write(raster_path, read(_zipfile_to_read(raster_name, zf)))
         close(zf)
     end
     return raster_path
 end
+function getraster(T::Type{WorldClim{Climate}}, layer::Symbol, months::AbstractArray, res::String)
+    getraster.(T, layer, months, Ref(res))
+end
 
 # Climate layers don't get their own folder
-rasterpath(T::Type{<:WorldClim{Climate}}, layer; resolution, month) = 
-    joinpath(_rasterpath(T, layer), rastername(T, layer; resolution, month))
+rasterpath(T::Type{<:WorldClim{Climate}}, layer; res, month) = 
+    joinpath(_rasterpath(T, layer), rastername(T, layer; res, month))
 _rasterpath(T::Type{<:WorldClim{Climate}}, layer) = joinpath(rasterpath(T), string(layer))
-rastername(T::Type{<:WorldClim{Climate}}, layer; resolution, month) = 
-    "wc2.1_$(resolution)_$(layer)_$(_pad2(month)).tif"
-zipname(T::Type{<:WorldClim{Climate}}, layer; resolution, month=1) = 
-    "wc2.1_$(resolution)_$(layer).zip"
-zipurl(T::Type{<:WorldClim{Climate}}, layer; resolution, month=1) =
-    joinpath(WORLDCLIM_URI, "base", zipname(T, layer; resolution, month))
-zippath(T::Type{<:WorldClim{Climate}}, layer; resolution, month=1) =
-    joinpath(rasterpath(T), "zips", zipname(T, layer; resolution, month))
+rastername(T::Type{<:WorldClim{Climate}}, layer; res, month) = 
+    "wc2.1_$(res)_$(layer)_$(_pad2(month)).tif"
+zipname(T::Type{<:WorldClim{Climate}}, layer; res, month=1) = 
+    "wc2.1_$(res)_$(layer).zip"
+zipurl(T::Type{<:WorldClim{Climate}}, layer; res, month=1) =
+    joinpath(WORLDCLIM_URI, "base", zipname(T, layer; res, month))
+zippath(T::Type{<:WorldClim{Climate}}, layer; res, month=1) =
+    joinpath(rasterpath(T), "zips", zipname(T, layer; res, month))
 
 _pad2(month) = lpad(month, 2, '0')

--- a/src/worldclim/shared.jl
+++ b/src/worldclim/shared.jl
@@ -10,6 +10,7 @@ struct WorldClim{X} <: RasterDataSource end
 const WORLDCLIM_URI = URI(scheme="https", host="biogeo.ucdavis.edu", path="/data/worldclim/v2.1")
 
 resolutions(::Type{<:WorldClim}) = ("30s", "2.5m", "5m", "10m")
+defres(::Type{<:WorldClim}) = "10m"
 
 rasterpath(::Type{WorldClim{T}}) where T = joinpath(rasterpath(), "WorldClim", string(nameof(T)))
 rasterpath(T::Type{<:WorldClim}, layer; kw...) =

--- a/test/earthenv-heterogeneity.jl
+++ b/test/earthenv-heterogeneity.jl
@@ -1,12 +1,12 @@
 @testset "EarthEnv HabitatHeterogeneity" begin
     using RasterDataSources: rastername, rasterurl, rasterpath
 
-    @test rastername(EarthEnv{HabitatHeterogeneity}, :cv; resolution=1) == "cv_1km.tif"
+    @test rastername(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == "cv_1km.tif"
     hh_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "EarthEnv", "habitat_heterogeneity")
     @test rasterpath(EarthEnv{HabitatHeterogeneity}) == hh_path
-    @test rasterpath(EarthEnv{HabitatHeterogeneity}, :cv; resolution=1) == joinpath(hh_path, "1km", "cv_1km.tif")
+    @test rasterpath(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == joinpath(hh_path, "1km", "cv_1km.tif")
 
-    @test rasterurl(EarthEnv{HabitatHeterogeneity}, :cv; resolution=1) == 
+    @test rasterurl(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == 
         URI(scheme="https", host="data.earthenv.org", path="/habitat_heterogeneity/1km/cv_01_05_1km_uint16.tif")
     getraster(EarthEnv{HabitatHeterogeneity}, :cv)
     @test isfile(joinpath(hh_path, "25km", "cv_25km.tif"))

--- a/test/geodata.jl
+++ b/test/geodata.jl
@@ -1,0 +1,78 @@
+using GeoData, RasterDataSources, Test, Dates, NCDatasets, ArchGDAL
+
+# Too big to test
+# @testset "load WorldClim Weather" begin
+#     # Weather time-series
+#     dates = (Date(2001), Date(2002))
+#     ser = series(WorldClim{Weather}, (:prec,); date=dates, window=(Lat(600:1900), Lon(600:1900)))
+#     ser[Date(2001, 1)][:prec]
+#     # Select Australia, using regular lat/lon selectors
+#     A = geoarray(WorldClim{Weather}, :prec; date=DateTime(2001, 05), mappedcrs=EPSG(4326))
+# end
+
+@testset "load WorldClim Climate" begin
+    # Weather time-series
+    ser = series(WorldClim{Climate}, (:prec,); res="10m", month=Jan:March)
+    ser[Jan][:prec] 
+    # Select Australia, using regular lat/lon selectors
+    A = geoarray(WorldClim{Climate}, :prec; month=1, mappedcrs=EPSG(4326))
+    A[Lat(Between(-10, -45)), Lon(Between(110, 160))]
+    st = stack(WorldClim{BioClim}, (1, 2))
+    st[:BIO1]
+    @test st isa DiskStack
+    @test A isa GDALarray
+end
+
+@testset "load WorldClim BioClim" begin
+    A = geoarray(WorldClim{BioClim}, 1; mappedcrs=EPSG(4326))
+    A[Lat(Between(-10, -45)), Lon(Between(110, 160))]
+    @test A isa GDALarray
+end
+
+@testset "load CHELSA BioClim" begin
+    A = geoarray(CHELSA{BioClim}, 1; mappedcrs=EPSG(4326))
+    A[Lat(Between(-10, -45)), Lon(Between(110, 160))]
+    st = stack(CHELSA{BioClim}, (1, 2))
+    @test A isa GDALarray
+    @test st isa DiskStack
+    @test st[:BIO2] isa GeoArray
+end
+
+@testset "load EarthEnv HabitatHeterogeneity" begin
+    A = geoarray(EarthEnv{HabitatHeterogeneity}, :cv; mappedcrs=EPSG(4326))
+    A[Lat(Between(-10, -45)), Lon(Between(110, 160))]
+    st = stack(EarthEnv{HabitatHeterogeneity}, (:cv, :evenness))
+    @test A isa GDALarray
+    @test st isa DiskStack
+    @test st[:evenness] isa GeoArray
+end
+
+@testset "load EarthEnv LandCover" begin
+    A = geoarray(EarthEnv{LandCover}, 2; mappedcrs=EPSG(4326))
+    A[Lat(Between(-10, -45)), Lon(Between(110, 160))]
+    @test A isa GDALarray
+end
+
+@testset "load ALWB" begin
+    A = geoarray(ALWB{Values,Day}, :ss_pct; date=DateTime(2019, 10, 19))
+    st = stack(ALWB{Values,Day}, (:s0_pct, :ss_pct); date=DateTime(2019, 10, 19))
+    dates = DateTime(2019, 10, 19):Day(1):DateTime(2019, 11, 20)
+    s = series(ALWB{Values,Day}, (:s0_pct, :ss_pct); date=dates)
+    @test A isa NCDarray
+    @test st isa DiskStack
+    @test s isa GeoSeries
+end
+
+if Sys.islinux()
+    @testset "load AWAP" begin
+        A = geoarray(AWAP, :rainfall; date=DateTime(2019, 10, 19))
+        st = stack(AWAP, (:tmax, :rainfall); date=DateTime(2019, 10, 19))
+        st[:tmax]
+        dates = DateTime(2019, 09, 19), DateTime(2019, 11, 19)
+        s = series(AWAP; date=dates)
+        s[DateTime(2019, 10, 1)][:solar]
+        @test A isa GDALarray
+        @test st isa DiskStack
+        @test s isa GeoSeries
+    end
+end

--- a/test/worldclim-bioclim.jl
+++ b/test/worldclim-bioclim.jl
@@ -2,11 +2,11 @@
     using RasterDataSources: rastername, zipurl, zipname, zippath
 
     zip_url = URI(scheme="https", host="biogeo.ucdavis.edu", path="/data/worldclim/v2.1/base/wc2.1_10m_bio.zip")
-    @test zipurl(WorldClim{BioClim}, 2; resolution="10m") == zip_url
-    @test zipname(WorldClim{BioClim}, 2; resolution="10m") == "wc2.1_10m_bio.zip"
+    @test zipurl(WorldClim{BioClim}, 2; res="10m") == zip_url
+    @test zipname(WorldClim{BioClim}, 2; res="10m") == "wc2.1_10m_bio.zip"
 
     raster_file = joinpath(ENV["RASTERDATASOURCES_PATH"], "WorldClim", "BioClim", "wc2.1_10m_bio_2.tif")
-    @test rasterpath(WorldClim{BioClim}, 2; resolution="10m") == raster_file
-    @test getraster(WorldClim{BioClim}, 2; resolution="10m") == raster_file
+    @test rasterpath(WorldClim{BioClim}, 2; res="10m") == raster_file
+    @test getraster(WorldClim{BioClim}, 2; res="10m") == raster_file
     @test isfile(raster_file)
 end

--- a/test/worldclim-climate.jl
+++ b/test/worldclim-climate.jl
@@ -3,11 +3,11 @@
     using RasterDataSources: rastername, rasterpath, zipurl, zipname, zippath
 
     zip_url = URI(scheme="https", host="biogeo.ucdavis.edu", path="/data/worldclim/v2.1/base/wc2.1_10m_wind.zip")
-    @test zipurl(WorldClim{Climate}, :wind; resolution="10m") == zip_url
-    @test zipname(WorldClim{Climate}, :wind; resolution="10m") == "wc2.1_10m_wind.zip"
+    @test zipurl(WorldClim{Climate}, :wind; res="10m") == zip_url
+    @test zipname(WorldClim{Climate}, :wind; res="10m") == "wc2.1_10m_wind.zip"
 
     raster_file = joinpath(ENV["RASTERDATASOURCES_PATH"], "WorldClim", "Climate", "wind", "wc2.1_10m_wind_01.tif")
-    @test rasterpath(WorldClim{Climate}, :wind; resolution="10m", month=1) == raster_file
-    @test getraster(WorldClim{Climate}, :wind; resolution="10m", month=1) == raster_file
+    @test rasterpath(WorldClim{Climate}, :wind; month=1, res="10m") == raster_file
+    @test getraster(WorldClim{Climate}, :wind; month=1, res="10m") == raster_file
     @test isfile(raster_file)
 end


### PR DESCRIPTION
Add `geoarray`, `stack` and `series` methods to load files directly with GeoData.jl.

Files will either be found or downloaded before opening, using `getraster`. Arguments are the same as `getraster`, but with additional keywords passed to the GeoData.jl constructor, such as `GDALarray`.

@virgile-baudrot this is probably the version you want, so you can delete these methods from scripts. Will make a 0.2 release as soon as tests pass and this is merged.