### PR TITLE
add interface file and fill out all the docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,8 @@ using Documenter, RasterDataSources
 
 makedocs(
     sitename = "RasterDataSources.jl",
+    checkdocs = :all,
+    strict = true,
 )
 
 deploydocs(

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,57 @@
 # RasterDataSources.jl
 
+```@docs
+RasterDataSources
+```
+
+# getraster
+
+RasterDataSources.jl only exports a single function, `getraster`.
+
 ```@autodocs
 Modules = [RasterDataSources]
+Private = false
+Order = [:function]
+```
+
+# Data sources
+
+```@docs
+RasterDataSources.RasterDataSource
+ALWB
+AWAP
+CHELSA
+EarthEnv
+WorldClim
+```
+
+# Datasets
+
+```@docs
+RasterDataSources.RasterDataSet
+BioClim
+Climate
+Weather
+LandCover
+HabitatHeterogeneity
+```
+
+# Other
+
+```julia
+Values
+Deciles
+```
+
+# Internal interface
+
+These methods are not exported at this stage, but are for the most part
+internally consistent. Any new sources added to the package should use these
+methods in a consistent way for readability, consistency and the potential to use
+them for other things later.
+
+```@autodocs
+Modules = [RasterDataSources]
+Public = false
+Order = [:function]
 ```

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -19,6 +19,7 @@ export Values, Deciles
 export getraster
 
 include("types.jl")
+include("interface.jl")
 include("shared.jl")
 include("worldclim/shared.jl")
 include("worldclim/bioclim.jl")

--- a/src/alwb/alwb.jl
+++ b/src/alwb/alwb.jl
@@ -6,9 +6,10 @@ abstract type DataMode end
 """
     Values <: DataMode
 
-Get as the regular measured values.
+Get the dataset as regular measured values.
 """
 struct Values <: DataMode end
+
 """
     Deciles <: DataMode
 
@@ -26,14 +27,14 @@ layers(::Type{<:ALWB}) = (
 @doc """
     ALWB{Union{Deciles,Values},Union{Day,Month,Year}} <: RasterDataSource
 
-Data from the Australian Landscape Water Balance (ALWB) data set.
+Data from the Australian Landscape Water Balance (ALWB) data source.
 
 See: [www.bom.gov.au/water/landscape](http://www.bom.gov.au/water/landscape)
 
-Layers are available in daily, monthly and 
+The available layers are: `$(layers(ALWB))`, available in daily, monthly and 
 annual resolutions, and as `Values` or relative `Deciles`.
 
-The available layers are: `$(layers(ALWB))`.
+`getraster` for `ALWB` must use a `date` keyword to specify the date to download.
 """ ALWB
 
 # http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/rain_day_2017.nc
@@ -45,11 +46,7 @@ The available layers are: `$(layers(ALWB))`.
 # http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/sd_pct_2017.nc
 # SoilMoisture_Deep = "sd_pct"
 # http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/sm_pct_2017.nc
-# SoilMoisture_RootZone = "sm_pct"
-
-# http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/qtot_2017.nc
-# Runoff = "qtot"
-
+# SoilMoisture_RootZone = "sm_pct" # http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/qtot_2017.nc # Runoff = "qtot"
 # http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/etot_2017.nc
 # Evapotrans_Actual = "etot"
 # http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/e0_2017.nc
@@ -73,13 +70,30 @@ The available layers are: `$(layers(ALWB))`.
 
 
 """
-    getraster(T::Type{<:ALWB{Union{Deciles,Values},Union{Day,Month,Year}}}, layer; date)
-    getraster(T::Type{<:ALWB{Union{Deciles,Values},Union{Day,Month,Year}}}, layer, date)
+    getraster(source::Type{<:ALWB{Union{Deciles,Values},Union{Day,Month,Year}}}, [layer]; date)
 
-Download ALWB weather data, choosing layers from: `$(layers(ALWB))`.
+Download [`ALWB`](@ref) weather data from 
+[www.bom.gov.au/water/landscape](http://www.bom.gov.au/water/landscape) as values or 
+deciles with timesteps of `Day`, `Month` or `Year`.
 
-Without a layer argument, all layers will be downloaded, and a tuple of path vectors returned. 
-If the data is already downloaded the path will be returned.
+# Arguments
+- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(layers(ALWB))`. Without a 
+    `layer` argument, all layers will be downloaded, and a `Vector` of paths returned.
+
+# Keywords
+- `date`: a `DateTime`, `AbstractVector` of `DateTime` or a `Tuple` of start and end dates.
+    For multiple dates, multiple filenames will be returned. AWAP is available with a daily
+    timestep.
+
+# Example
+This will return the file containing annual averages, including your date:
+
+```julia
+julia> getraster(ALWB{Values,Year}, :ss_pct; date=Date(2001, 2))
+"/your/RASTERDATASOURCES_PATH/ALWB/values/month/ss_pct.nc"
+```
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 getraster(T::Type{<:ALWB}, layer::Symbol; date) = getraster(T, layer, date)
 function getraster(T::Type{<:ALWB{M,P}}, layer::Symbol, dates::Tuple) where {M,P}

--- a/src/awap/awap.jl
+++ b/src/awap/awap.jl
@@ -23,22 +23,35 @@ const AWAP_PATHSEGMENTS = (
 # Add ndvi monthly?  ndvi, ndviave, month
 
 """
-    getraster(T::Type{AWAP}, layer::Symbol; date) => String
-    getraster(T::Type{AWAP}, layer::Symbol, date) => String
+    getraster(source::Type{AWAP}, [layer::Union{Tuple,Symbol}]; date::Union{DateTime,Tuple,AbstractVector})
+    getraster(T::Type{AWAP}, layer::Symbol, date::Union{DateTime,Tuple,AbstractVector})
 
-Download data from the AWAP weather dataset, for `layer` in `$(layers(AWAP))`,
-and `date` as a `DateTime` or iterable of `DateTime`.
+Download data from the [`AWAP`](@ref) weather dataset, from
+[www.csiro.au/awap](http://www.csiro.au/awap/).
 
-AWAP is available on a daily timestep. If no `layer` is specified, 
-all layers will be downloaded, and a `Tuple` of `Vector{String}` will be returned.
+# Arguments
+- `layer` `Symbol` or `Tuple` of `Symbol` for `layer`s in `$(layers(AWAP))`. Without a 
+    `layer` argument, all layers will be downloaded, and a tuple of paths returned.
 
-## Example
+# Keywords
+- `date`: a `DateTime`, `AbstractVector` of `DateTime` or a `Tuple` of start and end dates.
+    For multiple dates, multiple filenames will be returned. AWAP is available with a daily
+    timestep.
 
-Rainfall for the first month of 2001:
+# Example
+Download rainfall for the first month of 2001:
 
 ```julia
-getraster(AWAP, :rainfall; date=Date(2001, 1, 1):Day(1):Date(2001, 1, 31))
+julia> getraster(AWAP, :rainfall; date=Date(2001, 1, 1):Day(1):Date(2001, 1, 31))
+
+31-element Vector{String}:
+ "/your/path/AWAP/rainfall/totals/20010101.grid"
+ "/your/path/AWAP/rainfall/totals/20010102.grid"
+ ...
+ "/your/path/AWAP/rainfall/totals/20010131.grid"
 ```
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 getraster(T::Type{AWAP}, layer::Symbol; date) = getraster(T, layer, date)
 function getraster(T::Type{AWAP}, layer::Symbol, dates::Tuple)
@@ -76,7 +89,7 @@ function zipurl(T::Type{AWAP}, layer; date)
     joinpath(uri, s..., "grid/0.05/history/nat/$d$d.grid.Z")
 end
 zipname(T::Type{AWAP}, layer; date) = _date2string(T, date) * ".grid.Z"
-zippath(T::Type{AWAP}, layer; date) = 
+zippath(T::Type{AWAP}, layer; date) =
     joinpath(_rasterpath(T, layer), zipname(T, layer; date))
 
 

--- a/src/chelsa/bioclim.jl
+++ b/src/chelsa/bioclim.jl
@@ -1,21 +1,23 @@
 """
-    CHELSA{BioClim} <: RasterDataSource
+    CHELSA <: RasterDataSource
 
-Data from CHELSA, currently only the `BioClim` layer is implemented.
-
-See: [chelsa-climate.org](https://chelsa-climate.org/)
+Data from CHELSA, at [chelsa-climate.org](https://chelsa-climate.org/).
+Currently only the `BioClim` dataset is implemented.
 """
 struct CHELSA{X} <: RasterDataSource end
 
 layers(::Type{CHELSA{BioClim}}) = 1:19
 
 """
-    getraster(T::Type{CHELSA{BioClim}}, [layer::Integer]) => String
+    getraster(source::Type{CHELSA{BioClim}}, [layer::Union{Tuple,Integer}]) => Union{Tuple,String}
 
-Download CHELSA BioClim data, choosing layers from: `$(layers(CHELSA{BioClim}))`.
+Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https://chelsa-climate.org/).
 
-Without a layer argument, all layers will be downloaded, and a tuple of paths is returned. 
-If the data is already downloaded the path will be returned.
+# Arguments
+- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(CHELSA{BioClim}))`. 
+    Without a `layer` argument, all layers will be downloaded, and a `Vector` of paths returned.
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 function getraster(T::Type{CHELSA{BioClim}}, layer::Integer)
     _check_layer(T, layer)

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -6,15 +6,19 @@ layers(::Type{EarthEnv{HabitatHeterogeneity}}) = (
 )
 
 """
-    getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, [layer::Union{Tuple,Integer}]; res::Int=25) => String
-    getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Integer, res::Int=25) => String
+    getraster(source::Type{EarthEnv{HabitatHeterogeneity}}, [layer]; res="25km")
+    getraster(source::Type{EarthEnv{HabitatHeterogeneity}}, layer, res)
 
-Download EarthEnv habitat heterogeneity data, choosing `layer` from: 
-`$(layers(EarthEnv{HabitatHeterogeneity}))` and `res` from 
-`$(resolutions(EarthEnv{HabitatHeterogeneity}))`.
+Download [`EarthEnv`](@ref) habitat heterogeneity data.
 
-Without a layer argument, all layers will be downloaded and a tuple of paths returned. 
-If the data is already downloaded the path will be returned without the getraster.
+# Arguments
+- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(layers(EarthEnv{HabitatHeterogeneity}))`. 
+    Without a `layer` argument, all layers will be downloaded, and a tuple of paths returned.
+
+# Keywords
+- `res`: `String` chosen from `$(resolutions(EarthEnv{HabitatHeterogeneity}))`, defaulting to "25km".
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol; res::String=defres(T))
     getraster(T, layer, res)

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -1,13 +1,19 @@
 layers(::Type{EarthEnv{LandCover}}) = 1:12
 
 """
-    getraster(T::Type{EarthEnv{LandCover}}, [layer::Union{AbstractArray,Tuple,Integer}]; discover::Bool=false) => String
+    getraster(T::Type{EarthEnv{LandCover}}, [layer::Union{AbstractArray,Tuple,Integer}]; discover::Bool=false) => Union{Tuple,String}
     getraster(T::Type{EarthEnv{LandCover}}, layer::Integer, discover::Bool) => String
 
-Download EarthEnv landcover data, choosing `layer` from: `$(layers(EarthEnv{LandCover}))`.
+Download [`EarthEnv`](@ref) landcover data.
 
-Without a layer argument, all layers will be downloaded and a tuple of paths returned. 
-If the data is already downloaded the path will be returned.
+# Arguments
+- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(EarthEnv{LandCover}))`. 
+    Without a `layer` argument, all layers will be downloaded, and a tuple of paths returned.
+
+# Keywords
+- `discover::Bool` use the dataset that integrates the DISCover model.
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 function getraster(T::Type{EarthEnv{LandCover}}, layer::Integer; discover::Bool=false)
     getraster(T, layer, discover)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,0 +1,108 @@
+# Exported
+
+"""
+    getraster(source::Type, [layer]; kw...)
+
+`getraster` provides a standardised interface to download data sources,
+and return the filename/s of the selected files.
+
+RasterDataSources.jl aims to standardise an API for downloading many kinds of raster files
+from many sources, that can be wrapped by other packages (such as GeoData.jl and
+SimpleSDMLayers.jl) in a simple, regular way. As much as possible it will move towards
+having less source-specific keywords wherever possible. Similar datasets will behave in the
+same way so that they can be used interchangeably in the same code.
+
+# Arguments
+
+- `source`: defines the [`RasterDataSource`](@ref) and (if it there is more than one)
+    the specific [`RasterDataSet`](@ref) from which to download data.
+- `layer`: optionally choose the named or numbered layer/s of the data source.
+    If only the source argument is passed, all layers will be downloaded, returning a
+    `Tuple` of filenames.
+
+# Keywords
+
+Keyword arguments specify subsets of a data set, such as by date or resolution.
+As much as possible these are standardised for all sources where they are relevent.
+
+- `date`: `DateTime` date, range of dates, or tuple of start and end dates. Usually for weather datasets.
+- `month`: month or range of months to download for climatic datasets, as `Integer`s from 1 to 12.
+- `res`: spatial resolion of the file, as a `String` with units, e.g. "10m".
+
+The return value is either a single `String`, a `Tuple/Array` of `String`, or a
+`Tuple/Array` of `Tuple/Array` of `String` --- depending on the arguments. If multiple
+layers are specified, this may return multiple filenames. If multiple months or dates are
+specified, this may also return multiple filenames.
+"""
+function getraster end
+
+
+# Not exported, but relatively consistent and stable
+# These should be used for consistency accross all sources
+
+"""
+    rastername(source::Type, [layer]; kw...)
+
+Returns the name of the file, without downloading it.
+
+Arguments are the same as for `getraster`
+
+Returns a `String` or multiple `Strings`.
+"""
+function rastername end
+
+"""
+    rasterpath(source::Type, [layer]; kw...)
+
+Returns the name of the file, without downloading it.
+
+Arguments are the same as for `getraster`
+
+Returns a `String` or multiple `Strings`.
+"""
+function rasterpath end
+
+"""
+    rasterurl(source::Type, [layer]; kw...)
+
+If the file has a single url, returns it without downloading.
+
+Arguments are the same as for `getraster`.
+
+Returns a URIs.jl `URI` or mulitiple `URI`s.
+"""
+function rasterurl end
+
+"""
+    zipname(source::Type, [layer]; kw...)
+
+If the url is a zipped file, returns its name.
+
+Arguments are as the same for `getraster` where possible.
+
+Returns a `String` or multiple `Strings`.
+"""
+function zipname end
+
+"""
+    zippath(source::Type, [layer]; kw...)
+
+If the url is a zipped file, returns its path when downloaded.
+(This may not exist after extraction with `getraster`)
+
+Arguments are the same as for `getraster` where possible.
+
+Returns a `String` or multiple `Strings`.
+"""
+function zippath end
+
+"""
+    zipurl(source::Type, [layer]; kw...)
+
+If the url is a zipped file, returns its zip path without downloading.
+
+Arguments are the same as for `getraster` where possible.
+
+Returns a URIs.jl `URI` or mulitiple `URI`s.
+"""
+function zipurl end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,32 +1,38 @@
 """
-    RasterDataSource Abstract supertype for raster data collections.  """
+    RasterDataSource 
+
+Abstract supertype for raster data collections.  
+"""
 abstract type RasterDataSource end
 
 """
     RasterDataSet
 
-Abstract supertye for datasets that belong to a in a [`RasterDataSource`](@ref).
+Abstract supertye for datasets that belong to a [`RasterDataSource`](@ref).
 """
 abstract type RasterDataSet end
 
 """
     BioClim <: RasterDataSet
 
-BioClim datasets. Usually containing 19 numbered layers.
+BioClim datasets. Usually containing layers from 1:19. They do not use
+`month` or `date` keywords, but may allow `res` to be specified.
 """
 struct BioClim <: RasterDataSet end
 
 """
     Climate <: RasterDataSet
 
-Climate datasets. These are usually months of the year, not specific dates.
+Climate datasets. These are usually months of the year, not specific dates,
+and use a `month` keyword in `getraster`.
 """
 struct Climate <: RasterDataSet end
 
 """
     Weather <: RasterDataSet
 
-Weather datasets. These are usually large time-series of specific dates.
+Weather datasets. These are usually large time-series of specific dates,
+and use a `date` keyword in `getraster`.
 """
 struct Weather <: RasterDataSet end
 

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -1,14 +1,19 @@
 layers(::Type{WorldClim{BioClim}}) = 1:19
 
 """
-    getraster(T::Type{WorldClim{BioClim}}, [layer::Integer]; res::String="10m") => String
+    getraster(T::Type{WorldClim{BioClim}}, [layer::Union{Tuple,AbstractVector,Integer}]; res::String="10m") => Union{Tuple,AbstractVector,String}
     getraster(T::Type{WorldClim{BioClim}}, layer::Integer, res::String)
 
-Download WorldClim weather data, choosing `layer` from `$(layers(WorldClim{BioClim}))`,
-and `res` from `$(resolutions(WorldClim{BioClim}))`.
+Download [`WorldClim`](@ref) [`BioClim`](@ref) data.
 
-Without a layer argument, all layers will be downloaded, and a tuple of paths is returned. 
-If the data is already downloaded the path will be returned.
+# Arguments
+- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(WorldClim{BioClim}))`. 
+    Without a `layer` argument, all layers will be downloaded, and a `Vector` of paths returned.
+
+# Keywords
+- `res`: `String` chosen from $(resolutions(WorldClim{BioClim})), "10m" by default.
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 function getraster(T::Type{WorldClim{BioClim}}, layer::Integer; res::String=defres(T))
     getraster(T, layer, res)

--- a/src/worldclim/climate.jl
+++ b/src/worldclim/climate.jl
@@ -1,15 +1,21 @@
 layers(::Type{WorldClim{Climate}}) = (:tmin, :tmax, :tavg, :prec, :srad, :wind, :vapr)
 
 """
-    getraster(T::Type{WorldClim{Climate}}, [layer::Union{Symbol,Tuple}]; month=1:12, res::String="10m") => Vector{String}
+    getraster(T::Type{WorldClim{Climate}}, [layer::Union{Tuple,Symbol}]; month=1:12, res::String="10m") => Vector{String}
     getraster(T::Type{WorldClim{Climate}}, layer::Symbol, month::Integer, res::String)
 
-Download WorldClim weather data, choosing `layer` from $(layers(WorldClim{Climate})),
-and `res` from $(resolutions(WorldClim{Climate})), and months from `1:12`.
+Download [`WorldClim`](@ref) [`Climate`](@ref) data. 
 
-Without a layer argument, all layers will be downloaded, and a tuple of paths is returned. 
-By default all months are downloaded , but can also be downloaded individually.
-If the data is already downloaded the path will be returned.
+# Arguments
+- `layer` `Symbol` or `Tuple` of `Symbol` from `$(layers(WorldClim{Climate}))`. 
+    Without a `layer` argument, all layers will be downloaded, and a tuple of paths returned.
+
+# Keywords
+- `month`: `Integer` or `AbstractArray` of `Integer`. By default all months are downloaded,
+    but can be chosen from `1:12`.
+- `res`: `String` chosen from $(resolutions(WorldClim{Climate})), "10m" by default.
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 function getraster(T::Type{WorldClim{Climate}}, layer; month=1:12, res::String=defres(T))
     getraster(T, layer, month, res)
@@ -37,12 +43,12 @@ function getraster(T::Type{WorldClim{Climate}}, layer::Symbol, month::Integer, r
 end
 
 # Climate layers don't get their own folder
-rasterpath(T::Type{<:WorldClim{Climate}}, layer; res, month) = 
+rasterpath(T::Type{<:WorldClim{Climate}}, layer; res, month) =
     joinpath(_rasterpath(T, layer), rastername(T, layer; res, month))
 _rasterpath(T::Type{<:WorldClim{Climate}}, layer) = joinpath(rasterpath(T), string(layer))
-rastername(T::Type{<:WorldClim{Climate}}, layer; res, month) = 
+rastername(T::Type{<:WorldClim{Climate}}, layer; res, month) =
     "wc2.1_$(res)_$(layer)_$(_pad2(month)).tif"
-zipname(T::Type{<:WorldClim{Climate}}, layer; res, month=1) = 
+zipname(T::Type{<:WorldClim{Climate}}, layer; res, month=1) =
     "wc2.1_$(res)_$(layer).zip"
 zipurl(T::Type{<:WorldClim{Climate}}, layer; res, month=1) =
     joinpath(WORLDCLIM_URI, "base", zipname(T, layer; res, month))

--- a/src/worldclim/shared.jl
+++ b/src/worldclim/shared.jl
@@ -1,7 +1,8 @@
 """
     WorldClim{Union{BioClim,Climate,Weather}} <: RasterDataSource
 
-Data from WorldClim datasets, either `BioClim`, `Climate` or `Weather`
+Data from WorldClim datasets, either [`BioClim`](@ref), [`Climate`](@ref) or 
+[`Weather`](@ref).
 
 See: [www.worldclim.org](https://www.worldclim.org)
 """

--- a/src/worldclim/weather.jl
+++ b/src/worldclim/weather.jl
@@ -1,13 +1,17 @@
 layers(::Type{WorldClim{Weather}}) = (:tmin, :tmax, :prec)
 
 """
-    getraster(T::Type{WorldClim{Weather}}, [layer::Union{Symbol,Tuple}]; date) => Vector{String}
+    getraster(T::Type{WorldClim{Weather}}, [layer::Union{Tuple,Symbol}]; date) => Union{String,Tuple{String},Vector{String}}
     getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date)
 
-Download WorldClim weather data, choosing `layer` from: `$(layers(WorldClim{Weather}))`.
+Download [`WorldClim`](@ref) [`Weather`](@ref) data, for `layer`/s in: `$(layers(WorldClim{Weather}))`.
+Without a layer argument, all layers will be downloaded, and a tuple of paths returned. 
 
-Without a layer argument, all layers will be downloaded, and a tuple of paths is returned. 
-If the data is already downloaded the path will be returned.
+# Keywords
+- `date`: a `DateTime` or iterable of `DateTime`. For multiple dates, multiple 
+    filenames will be returned. WorldClim Weather is available with a daily timestep. 
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """
 function getraster(T::Type{WorldClim{Weather}}, layer::Symbol; date)
     getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date)


### PR DESCRIPTION
This PR makes the interface and the reasons behind it a little clearer. It also fills out the docs a lot and organises them sensibly, instead of just using `@autodocs`.