### PR TITLE
bugfix, refactor and standardise earthenv

### DIFF
--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -1,4 +1,4 @@
-layers(::Type{EarthEnv{LandCover}}) = 1:12
+layers(::Type{<:EarthEnv{<:LandCover}}) = 1:12
 
 """
     getraster(T::Type{EarthEnv{LandCover}}, [layer::Union{AbstractArray,Tuple,Integer}]; discover::Bool=false) => Union{Tuple,String}
@@ -7,34 +7,38 @@ layers(::Type{EarthEnv{LandCover}}) = 1:12
 Download [`EarthEnv`](@ref) landcover data.
 
 # Arguments
-- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(EarthEnv{LandCover}))`. 
+- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(EarthEnv{LandCover}))`.
     Without a `layer` argument, all layers will be downloaded, and a tuple of paths returned.
 
-# Keywords
-- `discover::Bool` use the dataset that integrates the DISCover model.
+`LandCover` may also be `LandCover{:DISCover} to download the dataset that integrates the DISCover model.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{EarthEnv{LandCover}}, layer::Integer; discover::Bool=false)
-    getraster(T, layer, discover)
-end
-function getraster(T::Type{EarthEnv{LandCover}}, layer::Integer, discover::Bool)
+function getraster(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)
     _check_layer(T, layer)
-    url = rasterurl(T, layer; discover)
-    path = rasterpath(T, layer; discover)
+    url = rasterurl(T, layer)
+    path = rasterpath(T, layer)
     return _maybe_download(url, path)
 end
 
-rasterpath(T::Type{EarthEnv{LandCover}}, layer::Integer; discover::Bool=false) =
-    joinpath(rasterpath(T), rastername(T, layer; discover))
-function rastername(::Type{EarthEnv{LandCover}}, layer::Integer; discover::Bool=false)
-    filetype = discover ? "complete" : "partial"
-    "landcover_$(filetype)_$(layer).tif"
+function rastername(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)
+    class = _discover(T) ? "consensus_full" : "Consensus_reduced"
+    "$(class)_class_" * string(layer) * ".tif"
 end
-function rasterurl(T::Type{EarthEnv{LandCover}}, layer::Integer; discover::Bool=false)
-    stem = discover ? "with_DISCover/consensus_full_class_$(layer).tif" :
-                      "without_DISCover/Consensus_reduced_class_$(layer).tif"
-    joinpath(rasterurl(T), stem)
+function rasterpath(T::Type{<:EarthEnv{<:LandCover}})
+    joinpath(rasterpath(EarthEnv), "LandCover", _discover_segment(T))
+end
+function rasterpath(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)
+    joinpath(rasterpath(T), rastername(T, layer))
+end
+function rasterurl(T::Type{<:EarthEnv{<:LandCover}})
+    joinpath(rasterurl(EarthEnv), "consensus_landcover", _discover_segment(T))
+end
+function rasterurl(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)
+    joinpath(rasterurl(T), rastername(T, layer))
 end
 
-_pathsegment(::Type{LandCover}) = "consensus_landcover"
+_discover(T::Type{EarthEnv{LandCover{:DISCover}}}) = true
+_discover(T::Type{<:EarthEnv{<:LandCover}}) = false
+
+_discover_segment(T) = _discover(T) ? "with_DISCover" : "without_DISCover"

--- a/src/earthenv/shared.jl
+++ b/src/earthenv/shared.jl
@@ -8,7 +8,5 @@ See: [www.earthenv.org](http://www.earthenv.org/)
 struct EarthEnv{X} <: RasterDataSource end
 
 rasterpath(::Type{EarthEnv}) = joinpath(rasterpath(), "EarthEnv")
-rasterpath(::Type{EarthEnv{X}}) where {X} = joinpath(rasterpath(EarthEnv), _pathsegment(X))
 
 rasterurl(::Type{EarthEnv}) = URI(scheme="https", host="data.earthenv.org")
-rasterurl(::Type{EarthEnv{X}}) where {X} = joinpath(rasterurl(EarthEnv), _pathsegment(X))

--- a/src/types.jl
+++ b/src/types.jl
@@ -41,7 +41,7 @@ struct Weather <: RasterDataSet end
 
 Land-cover datasets.
 """
-struct LandCover <: RasterDataSet end
+struct LandCover{X} <: RasterDataSet end
 
 """
     HabitatHeterogeneity <: RasterDataSet

--- a/test/earthenv-heterogeneity.jl
+++ b/test/earthenv-heterogeneity.jl
@@ -2,7 +2,7 @@
     using RasterDataSources: rastername, rasterurl, rasterpath
 
     @test rastername(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == "cv_1km.tif"
-    hh_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "EarthEnv", "habitat_heterogeneity")
+    hh_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "EarthEnv", "HabitatHeterogeneity")
     @test rasterpath(EarthEnv{HabitatHeterogeneity}) == hh_path
     @test rasterpath(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == joinpath(hh_path, "1km", "cv_1km.tif")
 

--- a/test/earthenv-landcover.jl
+++ b/test/earthenv-landcover.jl
@@ -1,12 +1,18 @@
 @testset "EarthEnv LandCover" begin
     using RasterDataSources: rastername, rasterurl, rasterpath
 
-    @test rastername(EarthEnv{LandCover}, 2; discover=true) == "landcover_complete_2.tif"
-    landcover_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "EarthEnv", "consensus_landcover")
-    @test rasterpath(EarthEnv{LandCover}) == landcover_path
-    @test rasterpath(EarthEnv{LandCover}, 2; discover=true) == joinpath(landcover_path, "landcover_complete_2.tif")
-    @test rasterurl(EarthEnv{LandCover}, 2; discover=true) == 
+    @test rastername(EarthEnv{LandCover{:DISCover}}, 2) == "consensus_full_class_2.tif"
+    landcover_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "EarthEnv", "LandCover")
+    @test rasterpath(EarthEnv{LandCover{:DISCover}}) == joinpath(landcover_path, "with_DISCover")
+    @test rasterpath(EarthEnv{LandCover}) == joinpath(landcover_path, "without_DISCover")
+    @test rasterpath(EarthEnv{LandCover{:DISCover}}, 2) == joinpath(landcover_path, "with_DISCover", "consensus_full_class_2.tif")
+    @test rasterurl(EarthEnv{LandCover{:DISCover}}, 2) ==
         URI(scheme="https", host="data.earthenv.org", path="/consensus_landcover/with_DISCover/consensus_full_class_2.tif")
+    getraster(EarthEnv{LandCover{:DISCover}}, 2)
+    @test isfile(joinpath(landcover_path, "with_DISCover", "consensus_full_class_2.tif"))
     getraster(EarthEnv{LandCover}, 2)
-    @test isfile(joinpath(landcover_path, "landcover_partial_2.tif"))
+    @test isfile(joinpath(landcover_path, "without_DISCover", "Consensus_reduced_class_2.tif"))
+    for layer in RasterDataSources.layers(EarthEnv{LandCover})
+        getraster(EarthEnv{LandCover{:DISCover}}, layer)
+    end
 end


### PR DESCRIPTION
EarthEnv downloads were not all working, this PR fixes all downloads.

The filenames and path were also quite custom, when other sources just use the original name of the file. As people don't really need to look at the names much this is easier and more consistent than thinking of new file names. In contrast, the folder was also using the url path instead of LandCover or HabitatHeterogeneity as other sources do (this may not be totally consistent yet).

`discover` was also the only keyword not related to spatial/temporal extent or grain. It's specifying the model used to generate the data, not a specific subset or resolution of the same data, so this is something for the source type.

This is a breaking change.

Closes #27