### PR TITLE
Standardise `getraster`

### DIFF
--- a/src/alwb/alwb.jl
+++ b/src/alwb/alwb.jl
@@ -95,7 +95,9 @@ julia> getraster(ALWB{Values,Year}, :ss_pct; date=Date(2001, 2))
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-getraster(T::Type{<:ALWB}, layers; date) = _getraster(T, layers, date)
+function getraster(T::Type{<:ALWB}, layers::Union{Tuple,Symbol}; date)
+     _getraster(T, layers, date)
+end
 
 function _getraster(T::Type{<:ALWB{M,P}}, layers, dates::Tuple) where {M,P}
     _getraster(T, layers, _date_sequence(dates, P(1)))

--- a/src/awap/awap.jl
+++ b/src/awap/awap.jl
@@ -53,11 +53,16 @@ julia> getraster(AWAP, :rainfall; date=Date(2001, 1, 1):Day(1):Date(2001, 1, 31)
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-getraster(T::Type{AWAP}, layer::Symbol; date) = getraster(T, layer, date)
-function getraster(T::Type{AWAP}, layer::Symbol, dates::Tuple)
-    getraster(T, layer, _date_sequence(dates, Day(1)))
+getraster(T::Type{AWAP}, layer; date) = _getraster(T, layer, date)
+
+function _getraster(T::Type{AWAP}, layer::Symbol, dates::Tuple{<:Any,<:Any})
+    _getraster(T, layer, _date_sequence(dates, Day(1)))
 end
-function getraster(T::Type{AWAP}, layer::Symbol, date::Dates.TimeType)
+function _getraster(T::Type{AWAP}, layers::Union{Tuple,Symbol}, dates::AbstractArray)
+    _getraster.(T, layers, dates)
+end
+_getraster(T::Type{<:AWAP}, layers::Tuple, date::Dates.TimeType) = _map_layers(T, layers, date)
+function _getraster(T::Type{AWAP}, layer::Symbol, date::Dates.TimeType)
     _check_layer(T, layer)
     mkpath(_rasterpath(T, layer))
     raster_path = rasterpath(T, layer; date=date)
@@ -67,9 +72,6 @@ function getraster(T::Type{AWAP}, layer::Symbol, date::Dates.TimeType)
         run(`uncompress $zip_path -f`)
     end
     return raster_path
-end
-function getraster(T::Type{AWAP}, layer::Symbol, dates::AbstractArray)
-    getraster.(T, layer, dates)
 end
 
 rasterpath(T::Type{AWAP}) = joinpath(rasterpath(), "AWAP")

--- a/src/awap/awap.jl
+++ b/src/awap/awap.jl
@@ -24,7 +24,6 @@ const AWAP_PATHSEGMENTS = (
 
 """
     getraster(source::Type{AWAP}, [layer::Union{Tuple,Symbol}]; date::Union{DateTime,Tuple,AbstractVector})
-    getraster(T::Type{AWAP}, layer::Symbol, date::Union{DateTime,Tuple,AbstractVector})
 
 Download data from the [`AWAP`](@ref) weather dataset, from
 [www.csiro.au/awap](http://www.csiro.au/awap/).
@@ -53,7 +52,7 @@ julia> getraster(AWAP, :rainfall; date=Date(2001, 1, 1):Day(1):Date(2001, 1, 31)
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-getraster(T::Type{AWAP}, layer; date) = _getraster(T, layer, date)
+getraster(T::Type{AWAP}, layer::Union{Tuple,Symbol}; date) = _getraster(T, layer, date)
 
 function _getraster(T::Type{AWAP}, layer::Symbol, dates::Tuple{<:Any,<:Any})
     _getraster(T, layer, _date_sequence(dates, Day(1)))
@@ -61,7 +60,9 @@ end
 function _getraster(T::Type{AWAP}, layers::Union{Tuple,Symbol}, dates::AbstractArray)
     _getraster.(T, layers, dates)
 end
-_getraster(T::Type{<:AWAP}, layers::Tuple, date::Dates.TimeType) = _map_layers(T, layers, date)
+function _getraster(T::Type{<:AWAP}, layers::Tuple, date::Dates.TimeType)
+    _map_layers(T, layers, date)
+end
 function _getraster(T::Type{AWAP}, layer::Symbol, date::Dates.TimeType)
     _check_layer(T, layer)
     mkpath(_rasterpath(T, layer))

--- a/src/chelsa/bioclim.jl
+++ b/src/chelsa/bioclim.jl
@@ -1,4 +1,5 @@
-layers(::Type{CHELSA{BioClim}}) = 1:19
+layers(::Type{CHELSA{BioClim}}) = layers(BioClim)
+layerkeys(::Type{CHELSA{BioClim}}, args...) = layerkeys(BioClim, args...)
 
 """
     getraster(source::Type{CHELSA{BioClim}}, [layer::Union{Tuple,Integer}]) => Union{Tuple,String}
@@ -11,7 +12,10 @@ Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{CHELSA{BioClim}}, layer::Integer)
+getraster(T::Type{CHELSA{BioClim}}, layers::Tuple) = _map_layers(T, layers)
+getraster(T::Type{CHELSA{BioClim}}, layer::Integer) = _getraster(T, layer)
+
+function _getraster(T::Type{CHELSA{BioClim}}, layer::Integer)
     _check_layer(T, layer)
     path = rasterpath(T, layer)
     url = rasterurl(T, layer)

--- a/src/chelsa/future.jl
+++ b/src/chelsa/future.jl
@@ -19,7 +19,9 @@ If the data is already downloaded the path will be returned.
 - `date`: A `Date` or `DateTime` object. Note that CHELSA CMIP5 only has two datasets,
     for the periods 2041-2060 and 2061-2080. Dates must fall in these ranges
 """
-function getraster(T::Type{<:CHELSA{<:Future{BioClim}}}, layers; date=Date(2050))
+function getraster(T::Type{<:CHELSA{<:Future{BioClim}}}, layers::Union{Tuple,Int,Symbol};
+    date=Date(2050)
+)
     _getraster(T, layers, date)
 end
 
@@ -37,7 +39,7 @@ If the data is already downloaded the path will be returned.
 - `month`: The month of the year, defaulting to all months, `1:12`.
 """
 function getraster(
-    T::Type{<:CHELSA{<:Future{Climate}}}, layers; date=Date(2050), month=months(Climate)
+    T::Type{<:CHELSA{<:Future{Climate}}}, layers::Union{Tuple,Symbol}; date=Date(2050), month=months(Climate)
 )
     _getraster(T, layers, date, month)
 end

--- a/src/chelsa/future.jl
+++ b/src/chelsa/future.jl
@@ -1,5 +1,7 @@
 
-layers(::Type{<:CHELSA{<:Future{BioClim}}}) = 1:19
+layers(::Type{<:CHELSA{<:Future{BioClim}}}) = layers(BioClim)
+layerkeys(T::Type{<:CHELSA{<:Future{BioClim}}}, args...) = layerkeys(BioClim, args...)
+
 layers(::Type{<:CHELSA{<:Future{Climate}}}) = (:prec, :temp, :tmin, :tmax)
 
 # A modified key is used in the file name, while the key is used as-is in the path
@@ -17,9 +19,10 @@ If the data is already downloaded the path will be returned.
 - `date`: A `Date` or `DateTime` object. Note that CHELSA CMIP5 only has two datasets,
     for the periods 2041-2060 and 2061-2080. Dates must fall in these ranges
 """
-function getraster(T::Type{<:CHELSA{<:Future{BioClim}}}, layer::Integer; date=Date(2050))
-    _getraster(T, layer; date)
+function getraster(T::Type{<:CHELSA{<:Future{BioClim}}}, layers; date=Date(2050))
+    _getraster(T, layers, date)
 end
+
 """
     getraster(T::Type{CHELSA{Future{Climate}}}, [layer::Integer]; date, month) => String
 
@@ -34,27 +37,37 @@ If the data is already downloaded the path will be returned.
 - `month`: The month of the year, defaulting to all months, `1:12`.
 """
 function getraster(
-    T::Type{<:CHELSA{<:Future{Climate}}}, layer::Symbol; date=Date(2050), month=1:12
+    T::Type{<:CHELSA{<:Future{Climate}}}, layers; date=Date(2050), month=months(Climate)
 )
-    _getraster(T, layer, date, month)
+    _getraster(T, layers, date, month)
 end
 
-function _getraster(T::Type{<:CHELSA{<:Future{Climate}}}, layer, date, months::AbstractArray)
-    map(month -> _getraster(T, layer, date, month), months)
-end
-function _getraster(T::Type{<:CHELSA{<:Future{Climate}}}, layer, dates::AbstractArray, month)
-    map(date -> _getraster(T, layer; date, month), dates)
+function _getraster(T::Type{<:CHELSA{<:Future{Climate}}}, layers, date, months::AbstractArray)
+    map(month -> _getraster(T, layers, date, month), months)
 end
 function _getraster(
-    T::Type{<:CHELSA{<:Future{Climate}}}, layer, dates::AbstractArray, months::AbstractArray
+    T::Type{<:CHELSA{<:Future{Climate}}}, layers, dates::AbstractArray, months::AbstractArray
 )
-    map(month -> _getraster(T, layer, dates, month), months)
+    map(date -> _getraster(T, layers, date, months), dates)
 end
-function _getraster(T::Type{<:CHELSA{<:Future{Climate}}}, layer, date, month)
-    _getraster(T, layer; date, month)
+function _getraster(T::Type{<:CHELSA{<:Future{Climate}}}, layers, dates::AbstractArray, month)
+    map(date -> _getraster(T, layers; date, month), dates)
+end
+function _getraster(T::Type{<:CHELSA{<:Future{Climate}}}, layers, date, month)
+    _getraster(T, layers; date, month)
+end
+function _getraster(T::Type{<:CHELSA{<:Future{BioClim}}}, layers, dates::AbstractArray)
+    map(date -> _getraster(T, layers, date), dates)
+end
+function _getraster(T::Type{<:CHELSA{<:Future{BioClim}}}, layers, date::TimeType)
+    _getraster(T, layers; date)
 end
 
-function _getraster(T::Type{<:CHELSA{<:Future}}, layer; kw...)
+# We have the extra args as keywords again to generalise rasterpath/rasterurl
+function _getraster(T::Type{<:CHELSA{<:Future}}, layers::Tuple; kw...)
+    _map_layers(T, layers; kw...)
+end
+function _getraster(T::Type{<:CHELSA{<:Future}}, layer::Union{Symbol,Integer}; kw...)
     _check_layer(T, layer)
     path = rasterpath(T, layer; kw...)
     url = rasterurl(T, layer; kw...)

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -20,10 +20,14 @@ Download [`EarthEnv`](@ref) habitat heterogeneity data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol; res::String=defres(T))
-    getraster(T, layer, res)
+function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers=layers(T); res::String=defres(T))
+    _getraster(T, layers, res)
 end
-function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol, res::String)
+
+function _getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers::Tuple, res::String)
+    return _map_layers(T, layers, res)
+end
+function _getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol, res::String)
     _check_layer(T, layer)
     _check_res(T, res)
     path = rasterpath(T, layer; res)

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -20,7 +20,9 @@ Download [`EarthEnv`](@ref) habitat heterogeneity data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers=layers(T); res::String=defres(T))
+function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers::Union{Tuple,Symbol}; 
+    res::String=defres(T)
+)
     _getraster(T, layers, res)
 end
 

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -33,7 +33,9 @@ Download [`EarthEnv`](@ref) landcover data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-getraster(T::Type{<:EarthEnv{<:LandCover}}, layers=layers(T)) = _getraster(T, layers)
+function getraster(T::Type{<:EarthEnv{<:LandCover}}, layers::Union{Tuple,Int})
+    _getraster(T, layers)
+end
 
 _getraster(T::Type{<:EarthEnv{<:LandCover}}, layers::Tuple) = _map_layers(T, layers)
 function _getraster(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -1,4 +1,23 @@
-layers(::Type{<:EarthEnv{<:LandCover}}) = 1:12
+layers(::Type{<:EarthEnv{<:LandCover}}) = ntuple(identity, Val{12}())
+
+function layerkeys(::Type{<:EarthEnv{<:LandCover}}) 
+    (
+        :NeedleleafTrees,
+        :EvergreenBroadleafTrees,
+        :DeciduousBroadleafTrees,
+        :OtherTrees,
+        :Shrubs,
+        :Herbaceous,
+        :CultivatedAndManaged,
+        :RegularlyFlooded,
+        :UrbanBuiltup,
+        :SnowIce,
+        :Barren,
+        :OpenWater,
+    )
+end
+layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layer::Int) = layerkeys(T)[layer]
+layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layers) = map(l -> layerkeys(T, l), layers)
 
 """
     getraster(T::Type{EarthEnv{LandCover}}, [layer::Union{AbstractArray,Tuple,Integer}]; discover::Bool=false) => Union{Tuple,String}
@@ -14,7 +33,10 @@ Download [`EarthEnv`](@ref) landcover data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)
+getraster(T::Type{<:EarthEnv{<:LandCover}}, layers=layers(T)) = _getraster(T, layers)
+
+_getraster(T::Type{<:EarthEnv{<:LandCover}}, layers::Tuple) = _map_layers(T, layers)
+function _getraster(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)
     _check_layer(T, layer)
     url = rasterurl(T, layer)
     path = rasterpath(T, layer)

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -10,8 +10,11 @@ Keyword arguments depend on the specific data source.
 The may modify the return value, following a pattern:
 - `month` keywords of `AbstractArray will return a `Vector{String}`
     or `Vector{<:NamedTuple}`.
-- `date` keywords of `AbstractArray` will also return a `Vector{String}`,
+- `date` keywords of `AbstractArray` will return a `Vector{String}` or
     `Vector{<:NamedTuple}`.
+- `date` keywords of `Tuple{start,end}` will take all the dates between the 
+    start and end dates, and also return `Vector{String}` or `Vector{<:NamedTuple}`.
+
 
 Where `date` and `month` keywords coexist, `Vector{Vector{String}}` of
 `Vector{Vector{NamedTuple}}` is the result. `date` ranges are always
@@ -22,6 +25,12 @@ This schema may be added to in future for datasets with additional axes,
 but should not change for the existing `RasterDataSource` types.
 """
 function getraster end
+# Vector layers are allowed, but converted to `Tuple` immediatedly.
+function getraster(T::Type, layers::AbstractArray; kw...)
+    getraster(T, (layers...,); kw...)
+end
+# Without a layers argument, all layers are downloaded
+getraster(T::Type; kw...) = getraster(T, layers(T); kw...)
 
 # Default assumption for `layerkeys` is that the layer
 # is the same as the layer key. This is not the case for

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -1,3 +1,27 @@
+"""
+    getraster(T::Type, layers::Union{Tuple,Int,Symbol}; kw...)
+
+Download raster layers `layers` from the data source `T`,
+returning a `String` for a single layer, or a `NamedTuple`
+for a `Tuple` of layers. `layer` values are usually values of
+`Symbol`, but can also be `Int` for `BioClim` datasets.
+
+Keyword arguments depend on the specific data source. 
+The may modify the return value, following a pattern:
+- `month` keywords of `AbstractArray will return a `Vector{String}`
+    or `Vector{<:NamedTuple}`.
+- `date` keywords of `AbstractArray` will also return a `Vector{String}`,
+    `Vector{<:NamedTuple}`.
+
+Where `date` and `month` keywords coexist, `Vector{Vector{String}}` of
+`Vector{Vector{NamedTuple}}` is the result. `date` ranges are always
+the outer `Vector`, `month` the inner `Vector` with `layer` tuples as
+the inner `NamedTuple`. No other keywords can be `Vector`.
+
+This schema may be added to in future for datasets with additional axes,
+but should not change for the existing `RasterDataSource` types.
+"""
+function getraster end
 
 # Default assumption for `layerkeys` is that the layer
 # is the same as the layer key. This is not the case for
@@ -20,7 +44,7 @@ function _maybe_download(uri::URI, filepath)
     filepath
 end
 
-function rasterpath() 
+function rasterpath()
     if haskey(ENV, "RASTERDATASOURCES_PATH") && isdir(ENV["RASTERDATASOURCES_PATH"])
         ENV["RASTERDATASOURCES_PATH"]
     else

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,6 +20,15 @@ BioClim datasets. Usually containing layers from 1:19. They do not usually use
 """
 struct BioClim <: RasterDataSet end
 
+# Bioclim has standardised layers for all data sources
+layers(::Type{BioClim}) = ntuple(identity, Val{19}())
+layerkeys(T::Type{BioClim}) = layerkeys(T, layers(T))
+layerkeys(T::Type{BioClim}, layers) = map(l -> bioclim_key(l), layers)
+
+bioclim_key(l::Symbol) = l
+bioclim_key(l::AbstractString) = Symbol(l)
+bioclim_key(l::Integer) = Symbol(string("bio", l))
+
 """
     Climate <: RasterDataSet
 
@@ -27,6 +36,8 @@ Climate datasets. These are usually months of the year, not specific dates,
 and use a `month` keyword in `getraster`. They may also use `date` in past/future scenarios.
 """
 struct Climate <: RasterDataSet end
+
+months(::Type{Climate}) = ntuple(identity, Val{12})
 
 """
     Weather <: RasterDataSet

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -16,7 +16,7 @@ Download [`WorldClim`](@ref) [`BioClim`](@ref) data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{WorldClim{BioClim}}, layers=layers(T); res::String=defres(T))
+function getraster(T::Type{WorldClim{BioClim}}, layers::Union{Tuple,Int}=layers(T); res::String=defres(T))
     _getraster(T, layers, res)
 end
 

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -1,4 +1,5 @@
-layers(::Type{WorldClim{BioClim}}) = 1:19
+layers(::Type{WorldClim{BioClim}}) = layers(BioClim)
+layerkeys(T::Type{WorldClim{BioClim}}, args...) = layerkeys(BioClim, args...)
 
 """
     getraster(T::Type{WorldClim{BioClim}}, [layer::Union{Tuple,AbstractVector,Integer}]; res::String="10m") => Union{Tuple,AbstractVector,String}
@@ -15,10 +16,12 @@ Download [`WorldClim`](@ref) [`BioClim`](@ref) data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{WorldClim{BioClim}}, layer::Integer; res::String=defres(T))
-    getraster(T, layer, res)
+function getraster(T::Type{WorldClim{BioClim}}, layers=layers(T); res::String=defres(T))
+    _getraster(T, layers, res)
 end
-function getraster(T::Type{WorldClim{BioClim}}, layer::Integer, res::String)
+
+_getraster(T::Type{WorldClim{BioClim}}, layers::Tuple, res) = _map_layers(T, layers, res)
+function _getraster(T::Type{WorldClim{BioClim}}, layer::Integer, res)
     _check_layer(T, layer)
     _check_res(T, res)
 

--- a/src/worldclim/climate.jl
+++ b/src/worldclim/climate.jl
@@ -17,16 +17,17 @@ Download [`WorldClim`](@ref) [`Climate`](@ref) data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{WorldClim{Climate}}, layer; month=1:12, res::String=defres(T))
-    getraster(T, layer, month, res)
+function getraster(T::Type{WorldClim{Climate}}, layers; month=months(Climate), res::String=defres(T))
+    _getraster(T, layers, month, res)
 end
-function getraster(T::Type{WorldClim{Climate}}, layers::Tuple, month, res::String)
-    map(l -> getraster(T, l, month, res), layers)
+
+function _getraster(T::Type{WorldClim{Climate}}, layers, month::AbstractArray, res::String)
+    _getraster.(T, Ref(layers), month, Ref(res))
 end
-function getraster(T::Type{WorldClim{Climate}}, layer::Symbol, month::AbstractArray, res::String)
-    getraster.(T, layer, month, Ref(res))
+function _getraster(T::Type{WorldClim{Climate}}, layers::Tuple, month::Integer, res::String)
+    _map_layers(T, layers, month, res)
 end
-function getraster(T::Type{WorldClim{Climate}}, layer::Symbol, month::Integer, res::String)
+function _getraster(T::Type{WorldClim{Climate}}, layer::Symbol, month::Integer, res::String)
     _check_layer(T, layer)
     _check_res(T, res)
     raster_path = rasterpath(T, layer; res, month)

--- a/src/worldclim/climate.jl
+++ b/src/worldclim/climate.jl
@@ -17,7 +17,9 @@ Download [`WorldClim`](@ref) [`Climate`](@ref) data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{WorldClim{Climate}}, layers; month=months(Climate), res::String=defres(T))
+function getraster(T::Type{WorldClim{Climate}}, layers::Union{Tuple,Symbol}; 
+    month=months(Climate), res::String=defres(T)
+)
     _getraster(T, layers, month, res)
 end
 

--- a/src/worldclim/weather.jl
+++ b/src/worldclim/weather.jl
@@ -13,13 +13,19 @@ Without a layer argument, all layers will be downloaded, and a tuple of paths re
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{WorldClim{Weather}}, layer::Symbol; date)
-    getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date)
+getraster(T::Type{WorldClim{Weather}}, layers; date) = _getraster(T, layers, date)
+
+function _getraster(T::Type{WorldClim{Weather}}, layers, date::Tuple)
+    _getraster(T, layers, _date_sequence(date, Month(1)))
 end
-function getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date::Tuple)
-    getraster(T, layer, _date_sequence(date, Month(1)))
+function _getraster(T::Type{WorldClim{Weather}}, layers, dates::AbstractArray)
+    @show layers
+    _getraster.(T, Ref(layers), dates)
 end
-function getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date::Dates.TimeType)
+function _getraster(T::Type{WorldClim{Weather}}, layers::Tuple, date::Dates.TimeType)
+    _map_layers(T, layers, date)
+end
+function _getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date::Dates.TimeType)
     decadestart = Date.(1960:10:2020)
     for i in eachindex(decadestart[1:end-1])
         # At least one date is in the decade
@@ -38,9 +44,6 @@ function getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date::Dates.TimeT
         return raster_path
     end
     error("Date $date not between 1960 and 2020")
-end
-function getraster(T::Type{WorldClim{Weather}}, layer::Symbol, dates::AbstractArray)
-    getraster.(T, layer, dates)
 end
 
 const WEATHER_DECADES = Dict(Date(1960) => "1960-1969",

--- a/src/worldclim/weather.jl
+++ b/src/worldclim/weather.jl
@@ -13,7 +13,9 @@ Without a layer argument, all layers will be downloaded, and a tuple of paths re
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-getraster(T::Type{WorldClim{Weather}}, layers; date) = _getraster(T, layers, date)
+function getraster(T::Type{WorldClim{Weather}}, layers::Union{Tuple,Symbol}; date)
+    _getraster(T, layers, date)
+end
 
 function _getraster(T::Type{WorldClim{Weather}}, layers, date::Tuple)
     _getraster(T, layers, _date_sequence(date, Month(1)))

--- a/test/alwb.jl
+++ b/test/alwb.jl
@@ -32,6 +32,6 @@
     @test getraster(ALWB{Values,Year}, :asce_pet; date=[DateTime(2018, 01, 01)]) == [raster_path]
     @test isfile(raster_path)
     raster_path = joinpath(alwb_path, "values", "year", "dd.nc")
-    @test getraster(ALWB{Values,Year}, (:dd,); date=DateTime(2018, 01, 01)) == (dd=raster_path,)
+    @test getraster(ALWB{Values,Year}, [:dd]; date=DateTime(2018, 01, 01)) == (dd=raster_path,)
     @test isfile(raster_path)
 end

--- a/test/alwb.jl
+++ b/test/alwb.jl
@@ -15,18 +15,23 @@
     @test rasterurl(ALWB{Values,Day}, :ss_pct; date=Date(2001, 1)) ==
         URI(scheme="http", host="www.bom.gov.au", path="/jsp/awra/thredds/fileServer/AWRACMS/values/day/ss_pct_2001.nc")
 
-    date = DateTime(2018, 01, 01), DateTime(2018, 03, 02)
-    getraster(ALWB{Values,Day}, :ss_pct; date)
-    @test isfile(joinpath(alwb_path, "values", "day", "ss_pct_2018.nc"))
-    getraster(ALWB{Deciles,Month}, :s0_pct; date)
-    @test isfile(joinpath(alwb_path, "deciles", "month", "s0_pct.nc"))
+    raster_path = joinpath(alwb_path, "values", "day", "ss_pct_2018.nc")
+    @test getraster(ALWB{Values,Day}, :ss_pct; date=DateTime(2018, 01, 01)) == raster_path
+    @test isfile(raster_path)
+    raster_path = joinpath(alwb_path, "deciles", "month", "s0_pct.nc")
+    @test getraster(ALWB{Deciles,Month}, :s0_pct; date=DateTime(2018, 01, 01)) == raster_path
+    @test isfile(raster_path)
 
-    getraster(ALWB{Values,Day}, :ma_wet; date)
-    @test isfile(joinpath(alwb_path, "values", "day", "ma_wet_2018.nc"))
-    getraster(ALWB{Values,Month}, :etot; date)
-    @test isfile(joinpath(alwb_path, "values", "month", "etot.nc"))
-    getraster(ALWB{Values,Year}, :asce_pet; date)
-    @test isfile(joinpath(alwb_path, "values", "year", "asce_pet.nc"))
-    getraster(ALWB{Values,Year}, :dd; date)
-    @test isfile(joinpath(alwb_path, "values", "year", "dd.nc"))
+    raster_path = joinpath(alwb_path, "values", "day", "ma_wet_2018.nc")
+    @test getraster(ALWB{Values,Day}, :ma_wet; date=DateTime(2018, 01, 01)) == raster_path
+    @test isfile(raster_path)
+    raster_path = joinpath(alwb_path, "values", "month", "etot.nc")
+    @test getraster(ALWB{Values,Month}, (:etot,); date=DateTime(2018, 01, 01)) == (etot=raster_path,)
+    @test isfile(raster_path)
+    raster_path = joinpath(alwb_path, "values", "year", "asce_pet.nc")
+    @test getraster(ALWB{Values,Year}, :asce_pet; date=[DateTime(2018, 01, 01)]) == [raster_path]
+    @test isfile(raster_path)
+    raster_path = joinpath(alwb_path, "values", "year", "dd.nc")
+    @test getraster(ALWB{Values,Year}, (:dd,); date=DateTime(2018, 01, 01)) == (dd=raster_path,)
+    @test isfile(raster_path)
 end

--- a/test/awap.jl
+++ b/test/awap.jl
@@ -12,8 +12,8 @@
     @test zipname(AWAP, :vprpress09; date=Date(2001, 1)) == "20010101.grid.Z"
 
     if Sys.islinux()
-        date = DateTime(2001, 01, 01), DateTime(2001, 01, 02)
-        getraster(AWAP, :vprpress09; date)
+        @test getraster(AWAP, :vprpress09; date=DateTime(2001, 01, 01)) == raster_file
+        @test getraster(AWAP, (:vprpress09,); date=DateTime(2001, 01, 01)) == (vprpress09=raster_file,)
         @test isfile(raster_file)
     end
 end

--- a/test/awap.jl
+++ b/test/awap.jl
@@ -14,6 +14,7 @@
     if Sys.islinux()
         @test getraster(AWAP, :vprpress09; date=DateTime(2001, 01, 01)) == raster_file
         @test getraster(AWAP, (:vprpress09,); date=DateTime(2001, 01, 01)) == (vprpress09=raster_file,)
+        @test getraster(AWAP, [:vprpress09]; date=DateTime(2001, 01, 01)) == (vprpress09=raster_file,)
         @test isfile(raster_file)
     end
 end

--- a/test/chelsa-bioclim.jl
+++ b/test/chelsa-bioclim.jl
@@ -15,5 +15,6 @@
     raster_path = joinpath(bioclim_path, "CHELSA_bio10_05.tif")
     @test getraster(CHELSA{BioClim}, 5) == raster_path
     @test getraster(CHELSA{BioClim}, (5,)) == (bio5=raster_path,)
+    @test getraster(CHELSA{BioClim}, [5]) == (bio5=raster_path,)
     @test isfile(raster_path)
 end

--- a/test/chelsa-bioclim.jl
+++ b/test/chelsa-bioclim.jl
@@ -1,5 +1,5 @@
 @testset "CHELSEA BioClim" begin
-    using RasterDataSources: rasterurl
+    using RasterDataSources: rasterurl, rasterpath
 
     @test rastername(CHELSA{BioClim}, 5) == "CHELSA_bio10_05.tif"
 
@@ -14,6 +14,6 @@
 
     raster_path = joinpath(bioclim_path, "CHELSA_bio10_05.tif")
     @test getraster(CHELSA{BioClim}, 5) == raster_path
-    @test getraster(CHELSA{BioClim}, (5,)) == (raster_path,)
+    @test getraster(CHELSA{BioClim}, (5,)) == (bio5=raster_path,)
     @test isfile(raster_path)
 end

--- a/test/chelsa-future.jl
+++ b/test/chelsa-future.jl
@@ -11,6 +11,7 @@ using RasterDataSources: rasterurl, rastername, rasterpath
 
     @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, 5) == raster_path
     @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, (5,)) == (bio5=raster_path,)
+    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, [5]) == (bio5=raster_path,)
     @test isfile(raster_path)
 end
 
@@ -25,6 +26,7 @@ end
     raster_path2 = joinpath(bioclim_path, "CHELSA_bio5_2071-2100_mri-esm2-0_ssp126_V.2.1.tif")
     @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, 5) == raster_path
     @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, (5,)) == (bio5=raster_path,)
+    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, [5]) == (bio5=raster_path,)
     @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, (5,); date=[Date(2050)]) == 
         [(bio5=raster_path,)]
     @test isfile(raster_path)
@@ -44,8 +46,8 @@ end
     @test rasterurl(CHELSA{Future{Climate,CMIP5,CCSM4,RCP45}}, :tmin; date=Date(2050), month=1) |> string ==
         "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V1/cmip5/2041-2060/tmin/CHELSA_tasmin_mon_CCSM4_rcp45_r1i1p1_g025.nc_1_2041-2060_V1.2.tif"
     @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; month=7) == raster_path
-    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; month=7) == raster_path
-    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; month=7:7) == [raster_path]
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, [:tmax]; month=7) == (tmax=raster_path,)
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, (:tmax,); month=7:7) == [(tmax=raster_path,)]
     @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; date=[Date(2050)], month=7:7) == [[raster_path]]
     @test isfile(raster_path)
 end
@@ -63,9 +65,10 @@ end
     temp_url = "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V2/GLOBAL/climatologies/2071-2100/GFDL-ESM4/ssp585/tas/" * temp_name
     @test rasterurl(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) |> string == temp_url
     @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) == raster_path
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, (:temp,); date=Date(2080), month=1) == (temp=raster_path,)
     # Month is the inner vector
-    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=[Date(2080)], month=1:2) == 
-        [[raster_path, raster_path2]]
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, [:temp]; date=[Date(2080)], month=1:2) == 
+        [[(temp=raster_path,), (temp=raster_path2,)]]
 
     @test isfile(raster_path)
 end

--- a/test/chelsa-future.jl
+++ b/test/chelsa-future.jl
@@ -10,6 +10,7 @@ using RasterDataSources: rasterurl, rastername, rasterpath
     raster_path = joinpath(bioclim_path, "CHELSA_bio_mon_CCSM4_rcp26_r1i1p1_g025.nc_5_2041-2060_V1.2.tif")
 
     @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, 5) == raster_path
+    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, (5,)) == (bio5=raster_path,)
     @test isfile(raster_path)
 end
 
@@ -21,7 +22,11 @@ end
     @test rasterpath(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}) == bioclim_path
 
     raster_path = joinpath(bioclim_path, bioclim_name)
+    raster_path2 = joinpath(bioclim_path, "CHELSA_bio5_2071-2100_mri-esm2-0_ssp126_V.2.1.tif")
     @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, 5) == raster_path
+    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, (5,)) == (bio5=raster_path,)
+    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, (5,); date=[Date(2050)]) == 
+        [(bio5=raster_path,)]
     @test isfile(raster_path)
 end
 
@@ -39,19 +44,28 @@ end
     @test rasterurl(CHELSA{Future{Climate,CMIP5,CCSM4,RCP45}}, :tmin; date=Date(2050), month=1) |> string ==
         "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V1/cmip5/2041-2060/tmin/CHELSA_tasmin_mon_CCSM4_rcp45_r1i1p1_g025.nc_1_2041-2060_V1.2.tif"
     @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; month=7) == raster_path
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; month=7) == raster_path
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; month=7:7) == [raster_path]
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; date=[Date(2050)], month=7:7) == [[raster_path]]
     @test isfile(raster_path)
 end
 
 @testset "CHELSA Future Climate CMIP6" begin
     temp_name = "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_01_2071_2100_norm.tif"
+    temp_name2 = "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_02_2071_2100_norm.tif"
     @test rastername(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) == temp_name
 
     climate_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "CHELSA", "Future", "Climate", "SSP585", "GFDLESM4")
     @test rasterpath(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}) == climate_path
     raster_path = joinpath(climate_path, temp_name)
+    raster_path2 = joinpath(climate_path, temp_name2)
     @test rasterpath(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) == raster_path
     temp_url = "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V2/GLOBAL/climatologies/2071-2100/GFDL-ESM4/ssp585/tas/" * temp_name
     @test rasterurl(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) |> string == temp_url
     @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) == raster_path
+    # Month is the inner vector
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=[Date(2080)], month=1:2) == 
+        [[raster_path, raster_path2]]
+
     @test isfile(raster_path)
 end

--- a/test/earthenv-heterogeneity.jl
+++ b/test/earthenv-heterogeneity.jl
@@ -11,5 +11,6 @@
     raster_path = joinpath(hh_path, "25km", "cv_25km.tif")
     @test getraster(EarthEnv{HabitatHeterogeneity}, :cv) == raster_path
     @test getraster(EarthEnv{HabitatHeterogeneity}, (:cv,)) == (cv=raster_path,)
+    @test getraster(EarthEnv{HabitatHeterogeneity}, [:cv]) == (cv=raster_path,)
     @test isfile(raster_path)
 end

--- a/test/earthenv-heterogeneity.jl
+++ b/test/earthenv-heterogeneity.jl
@@ -8,6 +8,8 @@
 
     @test rasterurl(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == 
         URI(scheme="https", host="data.earthenv.org", path="/habitat_heterogeneity/1km/cv_01_05_1km_uint16.tif")
-    getraster(EarthEnv{HabitatHeterogeneity}, :cv)
-    @test isfile(joinpath(hh_path, "25km", "cv_25km.tif"))
+    raster_path = joinpath(hh_path, "25km", "cv_25km.tif")
+    @test getraster(EarthEnv{HabitatHeterogeneity}, :cv) == raster_path
+    @test getraster(EarthEnv{HabitatHeterogeneity}, (:cv,)) == (cv=raster_path,)
+    @test isfile(raster_path)
 end

--- a/test/earthenv-landcover.jl
+++ b/test/earthenv-landcover.jl
@@ -12,10 +12,11 @@
     with_discover_path = joinpath(landcover_path, "with_DISCover", "consensus_full_class_2.tif")
     @test getraster(EarthEnv{LandCover{:DISCover}}, 2) == with_discover_path
     @test getraster(EarthEnv{LandCover{:DISCover}}, 2) == (EvergreenBroadleafTrees=with_discover_path)
-    @test isfile(without_discover_path)
+    @test isfile(with_discover_path)
     @test getraster(EarthEnv{LandCover}, 2) == without_discover_path
     @test getraster(EarthEnv{LandCover}, (2,)) == (EvergreenBroadleafTrees=without_discover_path,)
-    @test isfile(with_discover_path)
+    @test getraster(EarthEnv{LandCover}, [2]) == (EvergreenBroadleafTrees=without_discover_path,)
+    @test isfile(without_discover_path)
     for layer in RasterDataSources.layers(EarthEnv{LandCover})
         getraster(EarthEnv{LandCover{:DISCover}}, layer)
     end

--- a/test/earthenv-landcover.jl
+++ b/test/earthenv-landcover.jl
@@ -8,10 +8,14 @@
     @test rasterpath(EarthEnv{LandCover{:DISCover}}, 2) == joinpath(landcover_path, "with_DISCover", "consensus_full_class_2.tif")
     @test rasterurl(EarthEnv{LandCover{:DISCover}}, 2) ==
         URI(scheme="https", host="data.earthenv.org", path="/consensus_landcover/with_DISCover/consensus_full_class_2.tif")
-    getraster(EarthEnv{LandCover{:DISCover}}, 2)
-    @test isfile(joinpath(landcover_path, "with_DISCover", "consensus_full_class_2.tif"))
-    getraster(EarthEnv{LandCover}, 2)
-    @test isfile(joinpath(landcover_path, "without_DISCover", "Consensus_reduced_class_2.tif"))
+    without_discover_path = joinpath(landcover_path, "without_DISCover", "Consensus_reduced_class_2.tif")
+    with_discover_path = joinpath(landcover_path, "with_DISCover", "consensus_full_class_2.tif")
+    @test getraster(EarthEnv{LandCover{:DISCover}}, 2) == with_discover_path
+    @test getraster(EarthEnv{LandCover{:DISCover}}, 2) == (EvergreenBroadleafTrees=with_discover_path)
+    @test isfile(without_discover_path)
+    @test getraster(EarthEnv{LandCover}, 2) == without_discover_path
+    @test getraster(EarthEnv{LandCover}, (2,)) == (EvergreenBroadleafTrees=without_discover_path,)
+    @test isfile(with_discover_path)
     for layer in RasterDataSources.layers(EarthEnv{LandCover})
         getraster(EarthEnv{LandCover{:DISCover}}, layer)
     end

--- a/test/worldclim-bioclim.jl
+++ b/test/worldclim-bioclim.jl
@@ -8,6 +8,6 @@
     raster_file = joinpath(ENV["RASTERDATASOURCES_PATH"], "WorldClim", "BioClim", "wc2.1_10m_bio_2.tif")
     @test rasterpath(WorldClim{BioClim}, 2; res="10m") == raster_file
     @test getraster(WorldClim{BioClim}, 2; res="10m") == raster_file
-    @test getraster(WorldClim{BioClim}, (2,), "10m") == (raster_file,)
+    @test getraster(WorldClim{BioClim}, (2,); res="10m") == (bio2=raster_file,)
     @test isfile(raster_file)
 end

--- a/test/worldclim-bioclim.jl
+++ b/test/worldclim-bioclim.jl
@@ -9,5 +9,6 @@
     @test rasterpath(WorldClim{BioClim}, 2; res="10m") == raster_file
     @test getraster(WorldClim{BioClim}, 2; res="10m") == raster_file
     @test getraster(WorldClim{BioClim}, (2,); res="10m") == (bio2=raster_file,)
+    @test getraster(WorldClim{BioClim}, [2]; res="10m") == (bio2=raster_file,)
     @test isfile(raster_file)
 end

--- a/test/worldclim-climate.jl
+++ b/test/worldclim-climate.jl
@@ -8,7 +8,8 @@
 
     raster_file = joinpath(ENV["RASTERDATASOURCES_PATH"], "WorldClim", "Climate", "wind", "wc2.1_10m_wind_01.tif")
     @test rasterpath(WorldClim{Climate}, :wind; month=1, res="10m") == raster_file
-    @test getraster(WorldClim{Climate}, :wind; month=1, res="10m") == raster_file
-    @test getraster(WorldClim{Climate}, (:wind,), 1:1, "10m") == ([raster_file],)
+    @test getraster(WorldClim{Climate}, (:wind,); month=1, res="10m") == (wind=raster_file,)
+    @test getraster(WorldClim{Climate}, :wind; month=1:1, res="10m") == [raster_file]
+    @test getraster(WorldClim{Climate}, (:wind,); month=1:1, res="10m") == [(; wind=raster_file)]
     @test isfile(raster_file)
 end

--- a/test/worldclim-climate.jl
+++ b/test/worldclim-climate.jl
@@ -11,5 +11,6 @@
     @test getraster(WorldClim{Climate}, (:wind,); month=1, res="10m") == (wind=raster_file,)
     @test getraster(WorldClim{Climate}, :wind; month=1:1, res="10m") == [raster_file]
     @test getraster(WorldClim{Climate}, (:wind,); month=1:1, res="10m") == [(; wind=raster_file)]
+    @test getraster(WorldClim{Climate}, [:wind]; month=1:1, res="10m") == [(; wind=raster_file)]
     @test isfile(raster_file)
 end

--- a/test/worldclim-weather.jl
+++ b/test/worldclim-weather.jl
@@ -20,5 +20,6 @@
         raster_files = [joinpath(ENV["RASTERDATASOURCES_PATH"], "WorldClim", "Weather", "prec", "wc2.1_2.5m_prec_2001-$(lpad(string(x), 2, '0')).tif") for x in 1:12]
         @test getraster(WorldClim{Weather}, :prec; date=Date(2001):Month(1):Date(2001, 12)) == raster_files
         @test getraster(WorldClim{Weather}, (:prec,); date=Date(2001):Month(1):Date(2001, 12)) == map(f -> (prec=f,), raster_files)
+        @test getraster(WorldClim{Weather}, [:prec]; date=Date(2001):Month(1):Date(2001, 12)) == map(f -> (prec=f,), raster_files)
     end
 end

--- a/test/worldclim-weather.jl
+++ b/test/worldclim-weather.jl
@@ -15,6 +15,10 @@
 
     # These files are 3GB each. Too big to test in CI.
     if !haskey(ENV, "CI")
-        getraster(WorldClim{Weather}, :prec; date=Date(2001):Month(1):Date(2001, 12))
+        @test getraster(WorldClim{Weather}, :prec; date=Date(2001, 1)) == raster_file
+        @test getraster(WorldClim{Weather}, (:prec,); date=Date(2001, 1)) == (prec=raster_file,)
+        raster_files = [joinpath(ENV["RASTERDATASOURCES_PATH"], "WorldClim", "Weather", "prec", "wc2.1_2.5m_prec_2001-$(lpad(string(x), 2, '0')).tif") for x in 1:12]
+        @test getraster(WorldClim{Weather}, :prec; date=Date(2001):Month(1):Date(2001, 12)) == raster_files
+        @test getraster(WorldClim{Weather}, (:prec,); date=Date(2001):Month(1):Date(2001, 12)) == map(f -> (prec=f,), raster_files)
     end
 end


### PR DESCRIPTION
This PR further standardises the form and output of `getraster`.

- only the `getraster(T, layers; kw...)` form is exported
- `Symbol` or `Int` layers return a `String`
- `Tuple` of layers returns a `NamedTuple` of `String`
- `month` and `date` keywords can be `Vector`. These wrap the previous outputs in `Vector`.
- `date` is always the outer `Vector`, `month` the inner. (we can have climate for a particular time period, so there is the date of    the time period, and the cimate months as separate things).
- No other keyword arguments can be a `Vector`, without consideration, and updating this schema in the `getraster` docstring.

This should make it easier for scripts and external packages to handle more variation in datasets and keywords.