### PR TITLE
fix date and month args and add some traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Currently sources include :
 Please open an issue if you need more datasets added, or (even better) open a pull request 
 following the form of the other datasets where possible.
 
-## Retreiving data
+## Retrieving data
 
 Usage is generally via the `getraster` method - which will download the
 raster data source if it isn't available locally, or simply return the path/s
@@ -31,7 +31,7 @@ of the raster file/s:
 ```julia
 julia> using RasterDataSources
 
-julia> getraster(WorldClim{Climate}, :wind)
+julia> getraster(WorldClim{Climate}, :wind; month=1:12)
 12-element Array{String,1}:
  "/home/user/Data/WorldClim/Climate/wind/wc2.1_10m_wind_01.tif"
  "/home/user/Data/WorldClim/Climate/wind/wc2.1_10m_wind_02.tif"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,5 +7,5 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/cesaraustralia/RasterDataSources.jl.git",
+    repo = "github.com/EcoJulia/RasterDataSources.jl.git",
 )

--- a/src/chelsa/bioclim.jl
+++ b/src/chelsa/bioclim.jl
@@ -8,7 +8,7 @@ Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https
 
 # Arguments
 - `layer`: `Integer` or tuple/range of `Integer` from `$(layers(CHELSA{BioClim}))`. 
-    Without a `layer` argument, all layers will be downloaded, and a `Vector` of paths returned.
+    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -7,13 +7,12 @@ layers(::Type{EarthEnv{HabitatHeterogeneity}}) = (
 
 """
     getraster(source::Type{EarthEnv{HabitatHeterogeneity}}, [layer]; res="25km")
-    getraster(source::Type{EarthEnv{HabitatHeterogeneity}}, layer, res)
 
 Download [`EarthEnv`](@ref) habitat heterogeneity data.
 
 # Arguments
 - `layer`: `Symbol` or `Tuple` of `Symbol` from `$(layers(EarthEnv{HabitatHeterogeneity}))`.
-    Without a `layer` argument, all layers will be downloaded, and a tuple of paths returned.
+    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
 
 # Keywords
 - `res`: `String` chosen from `$(resolutions(EarthEnv{HabitatHeterogeneity}))`, defaulting to "25km".

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -20,14 +20,13 @@ layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layer::Int) = layerkeys(T)[layer]
 layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layers) = map(l -> layerkeys(T, l), layers)
 
 """
-    getraster(T::Type{EarthEnv{LandCover}}, [layer::Union{AbstractArray,Tuple,Integer}]; discover::Bool=false) => Union{Tuple,String}
-    getraster(T::Type{EarthEnv{LandCover}}, layer::Integer, discover::Bool) => String
+    getraster(T::Type{EarthEnv{LandCover}}, [layer]; discover::Bool=false) => Union{Tuple,String}
 
 Download [`EarthEnv`](@ref) landcover data.
 
 # Arguments
 - `layer`: `Integer` or tuple/range of `Integer` from `$(layers(EarthEnv{LandCover}))`.
-    Without a `layer` argument, all layers will be downloaded, and a tuple of paths returned.
+    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
 
 `LandCover` may also be `LandCover{:DISCover} to download the dataset that integrates the DISCover model.
 

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -38,6 +38,17 @@ getraster(T::Type; kw...) = getraster(T, layers(T); kw...)
 layerkeys(T::Type) = layers(T)
 layerkeys(T::Type, layers) = layers
 
+has_matching_layer_size(T) = true
+has_constant_dims(T) = true
+has_constant_metadata(T) = true
+
+date_sequence(T::Type, dates) = date_sequence(date_step(T), dates)
+date_sequence(step, date) = _date_sequence(step, date)
+
+_date_sequence(step, dates::AbstractArray) = dates
+_date_sequence(step, dates::NTuple{2}) = first(dates):step:last(dates)
+_date_sequence(step, date) = date:step:date
+
 function _maybe_download(uri::URI, filepath)
     if !isfile(filepath)
         mkpath(dirname(filepath))
@@ -77,10 +88,6 @@ _check_layer(T, layer) =
 
 _date2string(t, date) = Dates.format(date, _dateformat(t))
 _string2date(t, d::AbstractString) = Date(d, _dateformat(t))
-
-_date_sequence(dates::AbstractArray, step) = dates
-_date_sequence(dates::NTuple{2}, step) = first(dates):step:last(dates)
-_date_sequence(date, step) = date:step:date
 
 # Inner map over layers Tuple - month/date maps earlier
 # so we get Vectors of NamedTuples of filenames

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -3,13 +3,12 @@ layerkeys(T::Type{WorldClim{BioClim}}, args...) = layerkeys(BioClim, args...)
 
 """
     getraster(T::Type{WorldClim{BioClim}}, [layer::Union{Tuple,AbstractVector,Integer}]; res::String="10m") => Union{Tuple,AbstractVector,String}
-    getraster(T::Type{WorldClim{BioClim}}, layer::Integer, res::String)
 
 Download [`WorldClim`](@ref) [`BioClim`](@ref) data.
 
 # Arguments
 - `layer`: `Integer` or tuple/range of `Integer` from `$(layers(WorldClim{BioClim}))`. 
-    Without a `layer` argument, all layers will be downloaded, and a `Vector` of paths returned.
+    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
 
 # Keywords
 - `res`: `String` chosen from $(resolutions(WorldClim{BioClim})), "10m" by default.

--- a/src/worldclim/climate.jl
+++ b/src/worldclim/climate.jl
@@ -1,14 +1,13 @@
 layers(::Type{WorldClim{Climate}}) = (:tmin, :tmax, :tavg, :prec, :srad, :wind, :vapr)
 
 """
-    getraster(T::Type{WorldClim{Climate}}, [layer::Union{Tuple,Symbol}]; month=1:12, res::String="10m") => Vector{String}
-    getraster(T::Type{WorldClim{Climate}}, layer::Symbol, month::Integer, res::String)
+    getraster(T::Type{WorldClim{Climate}}, [layer::Union{Tuple,Symbol}]; month, res::String="10m") => Vector{String}
 
 Download [`WorldClim`](@ref) [`Climate`](@ref) data. 
 
 # Arguments
 - `layer` `Symbol` or `Tuple` of `Symbol` from `$(layers(WorldClim{Climate}))`. 
-    Without a `layer` argument, all layers will be downloaded, and a tuple of paths returned.
+    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
 
 # Keywords
 - `month`: `Integer` or `AbstractArray` of `Integer`. By default all months are downloaded,
@@ -18,7 +17,7 @@ Download [`WorldClim`](@ref) [`Climate`](@ref) data.
 Returns the filepath/s of the downloaded or pre-existing files.
 """
 function getraster(T::Type{WorldClim{Climate}}, layers::Union{Tuple,Symbol}; 
-    month=months(Climate), res::String=defres(T)
+    month, res::String=defres(T)
 )
     _getraster(T, layers, month, res)
 end

--- a/src/worldclim/weather.jl
+++ b/src/worldclim/weather.jl
@@ -1,15 +1,16 @@
 layers(::Type{WorldClim{Weather}}) = (:tmin, :tmax, :prec)
+date_step(::Type{WorldClim{Weather}}) = Month(1)
 
 """
     getraster(T::Type{WorldClim{Weather}}, [layer::Union{Tuple,Symbol}]; date) => Union{String,Tuple{String},Vector{String}}
-    getraster(T::Type{WorldClim{Weather}}, layer::Symbol, date)
 
 Download [`WorldClim`](@ref) [`Weather`](@ref) data, for `layer`/s in: `$(layers(WorldClim{Weather}))`.
-Without a layer argument, all layers will be downloaded, and a tuple of paths returned. 
+Without a layer argument, all layers will be downloaded, and a `NamedTuple` of paths returned. 
 
 # Keywords
-- `date`: a `DateTime` or iterable of `DateTime`. For multiple dates, multiple 
-    filenames will be returned. WorldClim Weather is available with a daily timestep. 
+
+- `date`: a `Date` or `DateTime` object, a `Vector` of dates, or `Tuple` of start/end dates.
+    WorldClim Weather is available with a daily timestep. 
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
@@ -18,7 +19,7 @@ function getraster(T::Type{WorldClim{Weather}}, layers::Union{Tuple,Symbol}; dat
 end
 
 function _getraster(T::Type{WorldClim{Weather}}, layers, date::Tuple)
-    _getraster(T, layers, _date_sequence(date, Month(1)))
+    _getraster(T, layers, date_sequence(T, date))
 end
 function _getraster(T::Type{WorldClim{Weather}}, layers, dates::AbstractArray)
     @show layers

--- a/test/chelsa-future.jl
+++ b/test/chelsa-future.jl
@@ -9,9 +9,9 @@ using RasterDataSources: rasterurl, rastername, rasterpath
 
     raster_path = joinpath(bioclim_path, "CHELSA_bio_mon_CCSM4_rcp26_r1i1p1_g025.nc_5_2041-2060_V1.2.tif")
 
-    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, 5) == raster_path
-    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, (5,)) == (bio5=raster_path,)
-    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, [5]) == (bio5=raster_path,)
+    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, 5; date=Date(2050)) == raster_path
+    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, (5,); date=Date(2050)) == (bio5=raster_path,)
+    @test getraster(CHELSA{Future{BioClim,CMIP5,CCSM4,RCP26}}, [5]; date=Date(2050)) == (bio5=raster_path,)
     @test isfile(raster_path)
 end
 
@@ -24,9 +24,9 @@ end
 
     raster_path = joinpath(bioclim_path, bioclim_name)
     raster_path2 = joinpath(bioclim_path, "CHELSA_bio5_2071-2100_mri-esm2-0_ssp126_V.2.1.tif")
-    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, 5) == raster_path
-    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, (5,)) == (bio5=raster_path,)
-    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, [5]) == (bio5=raster_path,)
+    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, 5; date=Date(2050)) == raster_path
+    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, (5,); date=Date(2050)) == (bio5=raster_path,)
+    @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, [5]; date=Date(2050)) == (bio5=raster_path,)
     @test getraster(CHELSA{Future{BioClim,CMIP6,MRIESM2,SSP126}}, (5,); date=[Date(2050)]) == 
         [(bio5=raster_path,)]
     @test isfile(raster_path)
@@ -45,30 +45,44 @@ end
         "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V1/cmip5/2041-2060/prec/CHELSA_pr_mon_CCSM4_rcp45_r1i1p1_g025.nc_6_2041-2060.tif"
     @test rasterurl(CHELSA{Future{Climate,CMIP5,CCSM4,RCP45}}, :tmin; date=Date(2050), month=1) |> string ==
         "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V1/cmip5/2041-2060/tmin/CHELSA_tasmin_mon_CCSM4_rcp45_r1i1p1_g025.nc_1_2041-2060_V1.2.tif"
-    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; month=7) == raster_path
-    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, [:tmax]; month=7) == (tmax=raster_path,)
-    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, (:tmax,); month=7:7) == [(tmax=raster_path,)]
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; date=Date(2050), month=7) == raster_path
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, [:tmax]; date=Date(2050), month=7) == (tmax=raster_path,)
+    @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, (:tmax,); date=Date(2050), month=7:7) == [(tmax=raster_path,)]
     @test getraster(CHELSA{Future{Climate,CMIP5,CCSM4,RCP60}}, :tmax; date=[Date(2050)], month=7:7) == [[raster_path]]
     @test isfile(raster_path)
 end
 
 @testset "CHELSA Future Climate CMIP6" begin
-    temp_name = "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_01_2071_2100_norm.tif"
-    temp_name2 = "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_02_2071_2100_norm.tif"
-    @test rastername(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) == temp_name
+    date_name =  "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_01_2011_2040_norm.tif"
+    date_name2 = "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_01_2041_2070_norm.tif"
+    date_name3 = "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_01_2071_2100_norm.tif"
+    month_name =  "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_01_2011_2040_norm.tif"
+    month_name2 = "CHELSA_gfdl-esm4_r1i1p1f1_w5e5_ssp585_tas_02_2011_2040_norm.tif"
+    @test rastername(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2030), month=1) == date_name
 
     climate_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "CHELSA", "Future", "Climate", "SSP585", "GFDLESM4")
     @test rasterpath(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}) == climate_path
-    raster_path = joinpath(climate_path, temp_name)
-    raster_path2 = joinpath(climate_path, temp_name2)
-    @test rasterpath(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) == raster_path
-    temp_url = "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V2/GLOBAL/climatologies/2071-2100/GFDL-ESM4/ssp585/tas/" * temp_name
-    @test rasterurl(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) |> string == temp_url
-    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2080), month=1) == raster_path
-    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, (:temp,); date=Date(2080), month=1) == (temp=raster_path,)
+    date_path = joinpath(climate_path, date_name)
+    date_path2 = joinpath(climate_path, date_name2)
+    date_path3 = joinpath(climate_path, date_name3)
+    month_path = joinpath(climate_path, month_name)
+    month_path2 = joinpath(climate_path, month_name2)
+    @test rasterpath(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2030), month=1) == date_path
+    @test rasterpath(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2030), month=1) == date_path
+    date_url = "https://os.zhdk.cloud.switch.ch/envicloud/chelsa/chelsa_V2/GLOBAL/climatologies/2011-2040/GFDL-ESM4/ssp585/tas/" * date_name
+    @test rasterurl(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2030), month=1) |> string == date_url
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2030), month=1) == date_path
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, (:temp,); date=Date(2030), month=1) == (temp=date_path,)
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, :temp; date=Date(2030), month=1) == date_path
     # Month is the inner vector
-    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, [:temp]; date=[Date(2080)], month=1:2) == 
-        [[(temp=raster_path,), (temp=raster_path2,)]]
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, [:temp]; date=[Date(2030)], month=1:2) == 
+        [[(temp=month_path,), (temp=month_path2,)]]
+    @test getraster(CHELSA{Future{Climate,CMIP6,GFDLESM4,SSP585}}, [:temp]; date=(Date(2030), Date(2090)), month=1:1) == 
+        [[(temp=date_path,)], [(temp=date_path2,)], [(temp=date_path3,)]]
 
-    @test isfile(raster_path)
+    @test isfile(date_path)
+    @test isfile(date_path2)
+    @test isfile(date_path3)
+    @test isfile(month_path)
+    @test isfile(month_path2)
 end


### PR DESCRIPTION
This PR:
- fixes the docs for recent changes
- adds missing interface methods, like `Tuple` of dates always working
- removes defaults for month/date. They are just confusing and hard to work with. `month` and `date` just have to be specified.
- add some traits for minor differences between types, not yet exported.