### PR TITLE
Better keys

### DIFF
--- a/src/awap/awap.jl
+++ b/src/awap/awap.jl
@@ -28,7 +28,7 @@ const AWAP_PATHSEGMENTS = (
 # Add ndvi monthly?  ndvi, ndviave, month
 
 """
-    getraster(source::Type{AWAP}, [layer::Union{Tuple,Symbol}]; date::Union{DateTime,Tuple,AbstractVector})
+    getraster(source::Type{AWAP}, [layer]; date)
 
 Download data from the [`AWAP`](@ref) weather dataset, from
 [www.csiro.au/awap](http://www.csiro.au/awap/). 

--- a/src/chelsa/bioclim.jl
+++ b/src/chelsa/bioclim.jl
@@ -2,7 +2,7 @@ layers(::Type{CHELSA{BioClim}}) = layers(BioClim)
 layerkeys(::Type{CHELSA{BioClim}}, args...) = layerkeys(BioClim, args...)
 
 """
-    getraster(source::Type{CHELSA{BioClim}}, [layer::Union{Tuple,Integer}]) => Union{Tuple,String}
+    getraster(source::Type{CHELSA{BioClim}}, [layer]) => Union{Tuple,String}
 
 Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https://chelsa-climate.org/).
 

--- a/src/chelsa/bioclim.jl
+++ b/src/chelsa/bioclim.jl
@@ -7,14 +7,16 @@ layerkeys(::Type{CHELSA{BioClim}}, args...) = layerkeys(BioClim, args...)
 Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https://chelsa-climate.org/).
 
 # Arguments
-- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(CHELSA{BioClim}))`. 
-    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
+- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(BioClim))`, 
+    or `Symbol`s form `$(layerkeys(BioClim))`. Without a `layer` argument, all layers
+    will be downloaded, and a `NamedTuple` of paths returned.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-getraster(T::Type{CHELSA{BioClim}}, layers::Tuple) = _map_layers(T, layers)
-getraster(T::Type{CHELSA{BioClim}}, layer::Integer) = _getraster(T, layer)
+getraster(T::Type{CHELSA{BioClim}}, layer::Union{Tuple,Int,Symbol}) = _getraster(T, layer)
 
+_getraster(T::Type{CHELSA{BioClim}}, layers::Tuple) = _map_layers(T, layers)
+_getraster(T::Type{CHELSA{BioClim}}, layer::Symbol) = _getraster(T, bioclim_int(layer))
 function _getraster(T::Type{CHELSA{BioClim}}, layer::Integer)
     _check_layer(T, layer)
     path = rasterpath(T, layer)

--- a/src/chelsa/future.jl
+++ b/src/chelsa/future.jl
@@ -11,7 +11,7 @@ date_step(::Type{<:CHELSA{<:Future{Climate,CMIP6}}}) = Year(30)
 const CHELSAKEY = (prec="pr", temp="tas", tmin="tasmin", tmax="tasmax", bio="bio")
 
 """
-    getraster(T::Type{CHELSA{Future{BioClim}}}, [layer::Integer]; date) => String
+    getraster(T::Type{CHELSA{Future{BioClim}}}, [layer]; date) => String
 
 Download CHELSA BioClim data, choosing layers from: `$(layers(CHELSA{BioClim}))`.
 
@@ -31,7 +31,7 @@ function getraster(
 end
 
 """
-    getraster(T::Type{CHELSA{Future{Climate}}}, [layer::Integer]; date, month) => String
+    getraster(T::Type{CHELSA{Future{Climate}}}, [layer]; date, month) => String
 
 Download CHELSA BioClim data, choosing layers from: `$(layers(CHELSA{BioClim}))`.
 

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -1,9 +1,31 @@
 resolutions(::Type{EarthEnv{HabitatHeterogeneity}}) = ("1km", "5km", "25km")
 defres(::Type{EarthEnv{HabitatHeterogeneity}}) = "25km"
-layers(::Type{EarthEnv{HabitatHeterogeneity}}) = (
-    :cv, :evenness, :range, :shannon, :simpson, :std, :Contrast, :Correlation,
-    :Dissimilarity, :Entropy, :Homogeneity, :Maximum, :Uniformity, :Variance
+layers(::Type{EarthEnv{HabitatHeterogeneity}}) = values(heterogeneity_lookup)
+layerkeys(::Type{EarthEnv{HabitatHeterogeneity}}) = keys(heterogeneity_lookup)
+layerkeys(T::Type{EarthEnv{HabitatHeterogeneity}}, layers) = map(l -> layerkeys(T, l), layers)
+function layerkeys(::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol)
+    Symbol(lowercase(string(layer)))
+end
+
+# Yes, they randomly chose cases
+const heterogeneity_lookup = (
+    cv = :cv,
+    evenness = :evenness,
+    range = :range,
+    shannon = :shannon,
+    simpson = :simpson,
+    std = :std,
+    contrast = :Contrast,
+    correlation = :Correlation,
+    dissimilarity = :Dissimilarity,
+    entropy = :Entropy,
+    homogeneity = :Homogeneity,
+    maximum = :Maximum,
+    uniformity = :Uniformity,
+    variance = :Variance,
 )
+
+heterogeneity_layer(x::Symbol) = heterogeneity_lookup[Symbol(lowercase(string(x)))]
 
 """
     getraster(source::Type{EarthEnv{HabitatHeterogeneity}}, [layer]; res="25km")
@@ -19,7 +41,7 @@ Download [`EarthEnv`](@ref) habitat heterogeneity data.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers::Union{Tuple,Symbol}; 
+function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers::Union{Tuple,Symbol};
     res::String=defres(T)
 )
     _getraster(T, layers, res)
@@ -29,6 +51,7 @@ function _getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers::Tuple, res:
     return _map_layers(T, layers, res)
 end
 function _getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layer::Symbol, res::String)
+    layer = heterogeneity_layer(layer)
     _check_layer(T, layer)
     _check_res(T, res)
     path = rasterpath(T, layer; res)

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -1,23 +1,24 @@
 layers(::Type{<:EarthEnv{<:LandCover}}) = ntuple(identity, Val{12}())
 
-function layerkeys(::Type{<:EarthEnv{<:LandCover}}) 
-    (
-        :NeedleleafTrees,
-        :EvergreenBroadleafTrees,
-        :DeciduousBroadleafTrees,
-        :OtherTrees,
-        :Shrubs,
-        :Herbaceous,
-        :CultivatedAndManaged,
-        :RegularlyFlooded,
-        :UrbanBuiltup,
-        :SnowIce,
-        :Barren,
-        :OpenWater,
-    )
-end
-layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layer::Int) = layerkeys(T)[layer]
+layerkeys(::Type{<:EarthEnv{<:LandCover}}) = keys(landcover_lookup)
 layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layers) = map(l -> layerkeys(T, l), layers)
+layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layer::Int) = layerkeys(T)[layer]
+layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layer::Symbol) = layer
+
+const landcover_lookup = (
+    needleleaf_trees = 1,
+    evergreen_broadleaf_trees = 2,
+    deciduous_broadleaf_trees = 3,
+    other_trees = 4,
+    shrubs = 5,
+    herbaceous = 6,
+    cultivated_and_managed = 7,
+    regularly_flooded = 8,
+    urban_builtup = 9,
+    snow_ice = 10,
+    barren = 11,
+    open_water = 12,
+)
 
 """
     getraster(T::Type{EarthEnv{LandCover}}, [layer]; discover::Bool=false) => Union{Tuple,String}
@@ -25,18 +26,21 @@ layerkeys(T::Type{<:EarthEnv{<:LandCover}}, layers) = map(l -> layerkeys(T, l), 
 Download [`EarthEnv`](@ref) landcover data.
 
 # Arguments
-- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(EarthEnv{LandCover}))`.
-    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
+
+- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(EarthEnv{LandCover}))`,
+    or `$(layerkeys(EarthEnv{LandCover}))`. Without a `layer` argument, all layers will
+    be downloaded, and a `NamedTuple` of paths returned.
 
 `LandCover` may also be `LandCover{:DISCover} to download the dataset that integrates the DISCover model.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{<:EarthEnv{<:LandCover}}, layers::Union{Tuple,Int})
+function getraster(T::Type{<:EarthEnv{<:LandCover}}, layers::Union{Tuple,Int,Symbol})
     _getraster(T, layers)
 end
 
 _getraster(T::Type{<:EarthEnv{<:LandCover}}, layers::Tuple) = _map_layers(T, layers)
+_getraster(T::Type{<:EarthEnv{<:LandCover}}, layer::Symbol) = _getraster(T, landcover_lookup[layer])
 function _getraster(T::Type{<:EarthEnv{<:LandCover}}, layer::Integer)
     _check_layer(T, layer)
     url = rasterurl(T, layer)

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -93,7 +93,6 @@ _string2date(t, d::AbstractString) = Date(d, _dateformat(t))
 # so we get Vectors of NamedTuples of filenames
 function _map_layers(T, layers, args...; kw...)
     filenames = map(layers) do l
-        _check_layer(T, l)
         _getraster(T, l, args...; kw...)
     end
     keys = layerkeys(T, layers)

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,13 +21,41 @@ BioClim datasets. Usually containing layers from 1:19. They do not usually use
 struct BioClim <: RasterDataSet end
 
 # Bioclim has standardised layers for all data sources
-layers(::Type{BioClim}) = ntuple(identity, Val{19}())
-layerkeys(T::Type{BioClim}) = layerkeys(T, layers(T))
-layerkeys(T::Type{BioClim}, layers) = map(l -> bioclim_key(l), layers)
+layers(::Type{BioClim}) = values(bioclim_lookup)
+layerkeys(T::Type{BioClim}) = keys(bioclim_lookup)
+layerkeys(T::Type{BioClim}, layer) = bioclim_key(layer)
+layerkeys(T::Type{BioClim}, layers::Tuple) = map(l -> bioclim_key(l), layers)
 
-bioclim_key(l::Symbol) = l
-bioclim_key(l::AbstractString) = Symbol(l)
-bioclim_key(l::Integer) = Symbol(string("bio", l))
+const bioclim_lookup = (
+    bio1 = 1,
+    bio2 = 2,
+    bio3 = 3,
+    bio4 = 4,
+    bio5 = 5,
+    bio6 = 6,
+    bio7 = 7,
+    bio8 = 8,
+    bio9 = 9,
+    bio10 = 10,
+    bio11 = 11,
+    bio12 = 12,
+    bio13 = 13,
+    bio14 = 14,
+    bio15 = 15,
+    bio16 = 16,
+    bio17 = 17,
+    bio18 = 18,
+    bio19 = 19,
+)
+
+# We allow a range of bioclim keys, as they are listed with 
+# a lot of variants on CHELSA and WorldClim
+bioclim_key(k::Symbol) = bioclim_key(string(k))
+bioclim_key(k::AbstractString) = Symbol(replace(lowercase(k), "_" => ""))
+bioclim_key(k::Integer) = keys(bioclim_lookup)[k]
+
+bioclim_int(k::Integer) = k
+bioclim_int(k::Symbol) = bioclim_lookup[bioclim_key(k)]
 
 """
     Climate <: RasterDataSet

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -7,19 +7,25 @@ layerkeys(T::Type{WorldClim{BioClim}}, args...) = layerkeys(BioClim, args...)
 Download [`WorldClim`](@ref) [`BioClim`](@ref) data.
 
 # Arguments
-- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(WorldClim{BioClim}))`. 
-    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
+
+- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(BioClim))`. 
+    or `Symbol`s from `$(layerkeys(BioClim))`. Without a `layer` argument, all layers
+    will be downloaded, and a `NamedTuple` of paths returned.
 
 # Keywords
+
 - `res`: `String` chosen from $(resolutions(WorldClim{BioClim})), "10m" by default.
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """
-function getraster(T::Type{WorldClim{BioClim}}, layers::Union{Tuple,Int}=layers(T); res::String=defres(T))
+function getraster(T::Type{WorldClim{BioClim}}, layers::Union{Tuple,Int,Symbol}; 
+    res::String=defres(T)
+)
     _getraster(T, layers, res)
 end
 
 _getraster(T::Type{WorldClim{BioClim}}, layers::Tuple, res) = _map_layers(T, layers, res)
+_getraster(T::Type{WorldClim{BioClim}}, layer::Symbol, res) = _getraster(T, bioclim_int(layer), res)
 function _getraster(T::Type{WorldClim{BioClim}}, layer::Integer, res)
     _check_layer(T, layer)
     _check_res(T, res)

--- a/test/chelsa-bioclim.jl
+++ b/test/chelsa-bioclim.jl
@@ -14,8 +14,9 @@ using RasterDataSources: rastername, rasterpath, rasterurl
         URI(scheme="https", host="os.zhdk.cloud.switch.ch", path="/envicloud/chelsa/chelsa_V1/climatologies/bio/CHELSA_bio10_05.tif")
 
     raster_path = joinpath(bioclim_path, "CHELSA_bio10_05.tif")
-    @test getraster(CHELSA{BioClim}, 5) == raster_path
+    @test getraster(CHELSA{BioClim}, :bio5) == raster_path
     @test getraster(CHELSA{BioClim}, (5,)) == (bio5=raster_path,)
-    @test getraster(CHELSA{BioClim}, [5]) == (bio5=raster_path,)
+    @test getraster(CHELSA{BioClim}, 5:5) == (bio5=raster_path,)
+    @test getraster(CHELSA{BioClim}, [:bio5]) == (bio5=raster_path,)
     @test isfile(raster_path)
 end

--- a/test/earthenv-heterogeneity.jl
+++ b/test/earthenv-heterogeneity.jl
@@ -4,16 +4,18 @@ using RasterDataSources: rastername, rasterpath, rasterurl
 @testset "EarthEnv HabitatHeterogeneity" begin
     using RasterDataSources: rastername, rasterurl, rasterpath
 
-    @test rastername(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == "cv_1km.tif"
+    @test rastername(EarthEnv{HabitatHeterogeneity}, :Dissimilarity; res="1km") == "Dissimilarity_1km.tif"
     hh_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "EarthEnv", "HabitatHeterogeneity")
     @test rasterpath(EarthEnv{HabitatHeterogeneity}) == hh_path
-    @test rasterpath(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == joinpath(hh_path, "1km", "cv_1km.tif")
+    @test rasterpath(EarthEnv{HabitatHeterogeneity}, :Dissimilarity; res="1km") == joinpath(hh_path, "1km", "Dissimilarity_1km.tif")
 
-    @test rasterurl(EarthEnv{HabitatHeterogeneity}, :cv; res="1km") == 
-        URI(scheme="https", host="data.earthenv.org", path="/habitat_heterogeneity/1km/cv_01_05_1km_uint16.tif")
-    raster_path = joinpath(hh_path, "25km", "cv_25km.tif")
-    @test getraster(EarthEnv{HabitatHeterogeneity}, :cv) == raster_path
-    @test getraster(EarthEnv{HabitatHeterogeneity}, (:cv,)) == (cv=raster_path,)
-    @test getraster(EarthEnv{HabitatHeterogeneity}, [:cv]) == (cv=raster_path,)
+    @test rasterurl(EarthEnv{HabitatHeterogeneity}, :Dissimilarity; res="1km") == 
+        URI(scheme="https", host="data.earthenv.org", path="/habitat_heterogeneity/1km/Dissimilarity_01_05_1km_uint32.tif")
+    raster_path = joinpath(hh_path, "25km", "Dissimilarity_25km.tif")
+    @test getraster(EarthEnv{HabitatHeterogeneity}, :dissimilarity; res="25km") == raster_path
+    @test getraster(EarthEnv{HabitatHeterogeneity}, (:Dissimilarity,)) == (dissimilarity=raster_path,)
+    @test getraster(EarthEnv{HabitatHeterogeneity}, [:dissimilarity]) == (dissimilarity=raster_path,)
     @test isfile(raster_path)
+    files = getraster(EarthEnv{HabitatHeterogeneity})
+    @test all(map(isfile, files))
 end

--- a/test/earthenv-landcover.jl
+++ b/test/earthenv-landcover.jl
@@ -14,11 +14,12 @@ using RasterDataSources: rastername, rasterpath, rasterurl
     without_discover_path = joinpath(landcover_path, "without_DISCover", "Consensus_reduced_class_2.tif")
     with_discover_path = joinpath(landcover_path, "with_DISCover", "consensus_full_class_2.tif")
     @test getraster(EarthEnv{LandCover{:DISCover}}, 2) == with_discover_path
-    @test getraster(EarthEnv{LandCover{:DISCover}}, 2) == (EvergreenBroadleafTrees=with_discover_path)
     @test isfile(with_discover_path)
-    @test getraster(EarthEnv{LandCover}, 2) == without_discover_path
-    @test getraster(EarthEnv{LandCover}, (2,)) == (EvergreenBroadleafTrees=without_discover_path,)
-    @test getraster(EarthEnv{LandCover}, [2]) == (EvergreenBroadleafTrees=without_discover_path,)
+    @test getraster(EarthEnv{LandCover}, :evergreen_broadleaf_trees) == without_discover_path
+    @test getraster(EarthEnv{LandCover}, (2,)) == (evergreen_broadleaf_trees=without_discover_path,)
+    @test getraster(EarthEnv{LandCover}, (:evergreen_broadleaf_trees,)) == (evergreen_broadleaf_trees=without_discover_path,)
+    @test getraster(EarthEnv{LandCover}, 2:2) == (evergreen_broadleaf_trees=without_discover_path,)
+    @test getraster(EarthEnv{LandCover}, [:evergreen_broadleaf_trees]) == (evergreen_broadleaf_trees=without_discover_path,)
     @test isfile(without_discover_path)
     for layer in RasterDataSources.layers(EarthEnv{LandCover})
         getraster(EarthEnv{LandCover{:DISCover}}, layer)

--- a/test/worldclim-bioclim.jl
+++ b/test/worldclim-bioclim.jl
@@ -8,8 +8,9 @@ using RasterDataSources: rastername, rasterpath, zipurl, zipname, zippath
 
     raster_file = joinpath(ENV["RASTERDATASOURCES_PATH"], "WorldClim", "BioClim", "wc2.1_10m_bio_2.tif")
     @test rasterpath(WorldClim{BioClim}, 2; res="10m") == raster_file
-    @test getraster(WorldClim{BioClim}, 2; res="10m") == raster_file
+    @test getraster(WorldClim{BioClim}, :bio2; res="10m") == raster_file
     @test getraster(WorldClim{BioClim}, (2,); res="10m") == (bio2=raster_file,)
-    @test getraster(WorldClim{BioClim}, [2]; res="10m") == (bio2=raster_file,)
+    @test getraster(WorldClim{BioClim}, 2:2; res="10m") == (bio2=raster_file,)
+    @test getraster(WorldClim{BioClim}, [:bio2]; res="10m") == (bio2=raster_file,)
     @test isfile(raster_file)
 end


### PR DESCRIPTION
allow using `:bio15` for bioclim, and e.g. `:evergreen_deciduous_trees` for landcover. 

Also resolves mixed case in harbitat heterogeneity dataset, so any case can be used.