### PR TITLE
Add SRTM dataset

### DIFF
--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -10,7 +10,7 @@ using Dates,
       URIs,
       ZipFile
 
-export WorldClim, CHELSA, EarthEnv, AWAP, ALWB
+export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM
 
 export BioClim, Climate, Weather, LandCover, HabitatHeterogeneity
 
@@ -54,5 +54,7 @@ include("earthenv/habitatheterogeneity.jl")
 include("awap/awap.jl")
 
 include("alwb/alwb.jl")
+
+include("srtm/srtm.jl")
 
 end # module

--- a/src/srtm/srtm.jl
+++ b/src/srtm/srtm.jl
@@ -1,0 +1,59 @@
+
+struct SRTM <: RasterDataSource end
+
+# SRTM Mirror with 5x5 degree tiles
+const SRTM_URI = URI(scheme = "https", host = "srtm.csi.cgiar.org", path = "/wp-content/uploads/files/srtm_5x5/TIFF")
+
+resolutions(::Type{SRTM}) = ("30m",)
+defres(::Type{SRTM}) = "30m"
+
+function _raster_tile_stem(tile_index::CartesianIndex)
+    y, x = tile_index.I
+    "srtm_$(lpad(x, 2, '0'))_$(lpad(y, 2, '0'))"
+end
+
+rastername(::Type{SRTM}, tile_index::CartesianIndex) = _raster_tile_stem(tile_index) * ".tif"
+rasterpath(::Type{SRTM}) = joinpath(rasterpath(), "SRTM")
+rasterpath(T::Type{SRTM}, tile_index::CartesianIndex) = joinpath(rasterpath(T), rastername(T, tile_index))
+
+zipname(::Type{SRTM}, tile_index) = _raster_tile_stem(tile_index) * ".zip"
+zipurl(T::Type{SRTM}, tile_index) = joinpath(SRTM_URI, zipname(T, tile_index))
+zippath(T::Type{SRTM}, tile_index) = joinpath(rasterpath(T), "zips", zipname(T, tile_index))
+
+
+function getraster(T::Type{SRTM}, tile_index)
+    raster_path = rasterpath(T, tile_index)
+    if !isfile(raster_path)
+        zip_path = zippath(T, tile_index)
+        _maybe_download(zipurl(T, tile_index), zip_path)
+        mkpath(dirname(raster_path))
+        raster_name = rastername(T, tile_index)
+        zf = ZipFile.Reader(zip_path)
+        write(raster_path, read(_zipfile_to_read(raster_name, zf)))
+        close(zf)
+    end
+    return raster_path
+end
+
+getraster(T::Type{SRTM}, tile_indices::CartesianIndices{2}) = getraster.(T, tile_indices)
+
+# Adapted from https://github.com/centreborelli/srtm4/blob/master/src/srtm4.c#L87-L117
+function wgs84_to_tile_index(x, y)
+    y = clamp(y, -60, 60)
+    # tiles longitude indexes go from 1 to 72,
+    # covering the range from -180 to +180
+    tile_x = (1 + floor(Int, (x + 180) / 5)) % 72
+    tile_x = tile_x == 0 ? 72 : tile_x
+
+    tile_y = 1 + floor(Int, (60 - y) / 5)
+    tile_y = tile_y == 25 ? 24 : tile_y
+    CartesianIndex(tile_y, tile_x)
+end
+
+
+function getraster(T::Type{SRTM}, bounds::NTuple{4,Real})
+    minx, miny, maxx, maxy = bounds
+    _min = wgs84_to_tile_index(minx, miny)
+    _max = wgs84_to_tile_index(maxx, maxy)
+    getraster(T, _min:_max)
+end

--- a/src/srtm/srtm.jl
+++ b/src/srtm/srtm.jl
@@ -54,7 +54,7 @@ function bounds_to_tile_indices(::Type{SRTM}, bounds::NTuple{4,Real})
 end
 
 
-for op = (:getraster, :rastername, :rasterpath, :zipname, :zipurl, :zippath)
+for op in (:getraster, :rastername, :rasterpath, :zipname, :zipurl, :zippath)
     _op = Symbol('_', op) # Name of internal function
     @eval begin
         # Broadcasting function dispatch
@@ -63,16 +63,16 @@ for op = (:getraster, :rastername, :rasterpath, :zipname, :zipurl, :zippath)
         $_op(T::Type{SRTM}, bounds::NTuple{4,Real}) = $_op(T, bounds_to_tile_indices(T, bounds))
 
         # Public function definition with key-word arguments
-        function $op(T::Type{SRTM}; bounds = nothing, tile_index = nothing)
-            if (bounds === nothing) & (tile_index === nothing)
+        function $op(T::Type{SRTM}; bounds=nothing, tile_index=nothing)
+            if isnothing(bounds) & isnothing(tile_index)
                 :op === :getraster || return joinpath(rasterpath(), "SRTM")
                 throw(ArgumentError("One of `bounds` or `tile_index` kwarg must be specified"))
-            elseif (bounds !== nothing) & (tile_index !== nothing)
+            elseif !isnothing(bounds) & !isnothing(tile_index)
                 throw(ArgumentError("Only on of `bounds` or `tile_index` should be specified. " *
                                     "found `bounds`=$bounds and `tile_index`=$tile_index"))
             else
                 # Call the internal function without key-word arguments
-                return $_op(T, tile_index === nothing ? bounds : tile_index)
+                return $_op(T, isnothing(tile_index) ? bounds : tile_index)
             end
         end
     end

--- a/src/srtm/srtm.jl
+++ b/src/srtm/srtm.jl
@@ -68,7 +68,7 @@ for op in (:getraster, :rastername, :rasterpath, :zipname, :zipurl, :zippath)
                 :op === :getraster || return joinpath(rasterpath(), "SRTM")
                 throw(ArgumentError("One of `bounds` or `tile_index` kwarg must be specified"))
             elseif !isnothing(bounds) & !isnothing(tile_index)
-                throw(ArgumentError("Only on of `bounds` or `tile_index` should be specified. " *
+                throw(ArgumentError("Only one of `bounds` or `tile_index` should be specified. " *
                                     "found `bounds`=$bounds and `tile_index`=$tile_index"))
             else
                 # Call the internal function without key-word arguments

--- a/src/srtm/srtm.jl
+++ b/src/srtm/srtm.jl
@@ -14,7 +14,7 @@ _rasterpath(T::Type{SRTM}, tile_index::CartesianIndex{2}) = joinpath(rasterpath(
 
 _zipname(::Type{SRTM}, tile_index::CartesianIndex{2}) = _raster_tile_stem(tile_index) * ".zip"
 _zipurl(T::Type{SRTM}, tile_index::CartesianIndex{2}) = joinpath(SRTM_URI, _zipname(T, tile_index))
-_zippath(T::Type{SRTM}, tile_index::CartesianIndex{2}) = joinpath(rasterpath(), "SRTM", "zips", zipname(T, tile_index))
+_zippath(T::Type{SRTM}, tile_index::CartesianIndex{2}) = joinpath(rasterpath(), "SRTM", "zips", _zipname(T, tile_index))
 
 
 function _getraster(T::Type{SRTM}, tile_index::CartesianIndex{2})

--- a/src/srtm/srtm.jl
+++ b/src/srtm/srtm.jl
@@ -53,11 +53,10 @@ function bounds_to_tile_indices(::Type{SRTM}, bounds::NTuple{4,Real})
     _min:_max
 end
 
-#rasterpath(::Type{SRTM}) = joinpath(rasterpath(), "SRTM")
 
 for op = (:getraster, :rastername, :rasterpath, :zipname, :zipurl, :zippath)
     _op = Symbol('_', op) # Name of internal function
-    eval(quote
+    @eval begin
         # Broadcasting function dispatch
         $_op(T::Type{SRTM}, tile_index::CartesianIndices) = $(_op).(T, tile_index)
         # Bounds to tile indices dispatch
@@ -76,5 +75,5 @@ for op = (:getraster, :rastername, :rasterpath, :zipname, :zipurl, :zippath)
                 return $_op(T, tile_index === nothing ? bounds : tile_index)
             end
         end
-    end)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,3 +20,4 @@ end
 @time @safetestset "worldclim bioclim" begin include("worldclim-bioclim.jl") end
 @time @safetestset "worldclim climate" begin include("worldclim-climate.jl") end
 @time @safetestset "worldclim weather" begin include("worldclim-weather.jl") end
+@time @safetestset "srtm" begin include("srtm.jl") end

--- a/test/srtm.jl
+++ b/test/srtm.jl
@@ -7,20 +7,20 @@ using RasterDataSources: rasterpath, zipurl, zipname
     zip_url = URI(scheme = "https", host = "srtm.csi.cgiar.org", path = "/wp-content/uploads/files/srtm_5x5/TIFF/srtm_01_02.zip")
     tile_index1 = CartesianIndex(2, 1)   # [y, x] order
     tile_index2 = CartesianIndex(2, 2)   # [y, x] order
-    @test zipurl(SRTM, tile_index1) == zip_url
-    @test zipurl(SRTM, tile_index1) == zip_url
-    @test zipname(SRTM, tile_index1) == "srtm_01_02.zip"
+    @test zipurl(SRTM, tile_index = tile_index1) == zip_url
+    @test zipurl(SRTM, tile_index = tile_index1) == zip_url
+    @test zipname(SRTM, tile_index = tile_index1) == "srtm_01_02.zip"
 
     raster_path1 = joinpath(ENV["RASTERDATASOURCES_PATH"], "SRTM", "srtm_01_02.tif")
     raster_path2 = joinpath(ENV["RASTERDATASOURCES_PATH"], "SRTM", "srtm_02_02.tif")
-    @test rasterpath(SRTM, tile_index1) == raster_path1
-    @test getraster(SRTM, tile_index1) == raster_path1
+    @test rasterpath(SRTM, tile_index = tile_index1) == raster_path1
+    @test getraster(SRTM, tile_index = tile_index1) == raster_path1
     @test isfile(raster_path1)
 
     lon1, lat1 = -180, 55       # Coordinates of [0, 0] pixel of tile x=1, y=2
-    @test RasterDataSources.wgs84_to_tile_index(lon1, lat1) == tile_index1
-    @test getraster(SRTM, (lon1, lat1, lon1, lat1)) == [raster_path1;;]
+    @test RasterDataSources._wgs84_to_tile_index(lon1, lat1) == tile_index1
+    @test getraster(SRTM, bounds = (lon1, lat1, lon1, lat1)) == reshape([raster_path1], 1, 1)
     lon2, lat2 = -172.5, 52.5   # Coordinates of [3000, 3000] pixel of tile x=2, y=2
-    @test RasterDataSources.wgs84_to_tile_index(lon2, lat2) == tile_index2
-    @test getraster(SRTM, (lon1, lat1, lon2, lat2)) == [raster_path1;; raster_path2]
+    @test RasterDataSources._wgs84_to_tile_index(lon2, lat2) == tile_index2
+    @test getraster(SRTM, bounds = (lon1, lat1, lon2, lat2)) == reshape([raster_path1, raster_path2], 1, 2)
 end

--- a/test/srtm.jl
+++ b/test/srtm.jl
@@ -1,0 +1,26 @@
+
+using RasterDataSources, URIs, Test, Dates
+using RasterDataSources: rasterpath, zipurl, zipname
+
+@testset "SRTM" begin
+
+    zip_url = URI(scheme = "https", host = "srtm.csi.cgiar.org", path = "/wp-content/uploads/files/srtm_5x5/TIFF/srtm_01_02.zip")
+    tile_index1 = CartesianIndex(2, 1)   # [y, x] order
+    tile_index2 = CartesianIndex(2, 2)   # [y, x] order
+    @test zipurl(SRTM, tile_index1) == zip_url
+    @test zipurl(SRTM, tile_index1) == zip_url
+    @test zipname(SRTM, tile_index1) == "srtm_01_02.zip"
+
+    raster_path1 = joinpath(ENV["RASTERDATASOURCES_PATH"], "SRTM", "srtm_01_02.tif")
+    raster_path2 = joinpath(ENV["RASTERDATASOURCES_PATH"], "SRTM", "srtm_02_02.tif")
+    @test rasterpath(SRTM, tile_index1) == raster_path1
+    @test getraster(SRTM, tile_index1) == raster_path1
+    @test isfile(raster_path1)
+
+    lon1, lat1 = -180, 55       # Coordinates of [0, 0] pixel of tile x=1, y=2
+    @test RasterDataSources.wgs84_to_tile_index(lon1, lat1) == tile_index1
+    @test getraster(SRTM, (lon1, lat1, lon1, lat1)) == [raster_path1;;]
+    lon2, lat2 = -172.5, 52.5   # Coordinates of [3000, 3000] pixel of tile x=2, y=2
+    @test RasterDataSources.wgs84_to_tile_index(lon2, lat2) == tile_index2
+    @test getraster(SRTM, (lon1, lat1, lon2, lat2)) == [raster_path1;; raster_path2]
+end

--- a/test/srtm.jl
+++ b/test/srtm.jl
@@ -7,20 +7,20 @@ using RasterDataSources: rasterpath, zipurl, zipname
     zip_url = URI(scheme = "https", host = "srtm.csi.cgiar.org", path = "/wp-content/uploads/files/srtm_5x5/TIFF/srtm_01_02.zip")
     tile_index1 = CartesianIndex(2, 1)   # [y, x] order
     tile_index2 = CartesianIndex(2, 2)   # [y, x] order
-    @test zipurl(SRTM, tile_index = tile_index1) == zip_url
-    @test zipurl(SRTM, tile_index = tile_index1) == zip_url
-    @test zipname(SRTM, tile_index = tile_index1) == "srtm_01_02.zip"
+    @test zipurl(SRTM; tile_index = tile_index1) == zip_url
+    @test zipurl(SRTM; tile_index = tile_index1) == zip_url
+    @test zipname(SRTM; tile_index = tile_index1) == "srtm_01_02.zip"
 
     raster_path1 = joinpath(ENV["RASTERDATASOURCES_PATH"], "SRTM", "srtm_01_02.tif")
     raster_path2 = joinpath(ENV["RASTERDATASOURCES_PATH"], "SRTM", "srtm_02_02.tif")
-    @test rasterpath(SRTM, tile_index = tile_index1) == raster_path1
-    @test getraster(SRTM, tile_index = tile_index1) == raster_path1
+    @test rasterpath(SRTM; tile_index = tile_index1) == raster_path1
+    @test getraster(SRTM; tile_index = tile_index1) == raster_path1
     @test isfile(raster_path1)
 
     lon1, lat1 = -180, 55       # Coordinates of [0, 0] pixel of tile x=1, y=2
     @test RasterDataSources._wgs84_to_tile_index(lon1, lat1) == tile_index1
-    @test getraster(SRTM, bounds = (lon1, lat1, lon1, lat1)) == reshape([raster_path1], 1, 1)
+    @test getraster(SRTM; bounds = (lon1, lat1, lon1, lat1)) == reshape([raster_path1], 1, 1)
     lon2, lat2 = -172.5, 52.5   # Coordinates of [3000, 3000] pixel of tile x=2, y=2
     @test RasterDataSources._wgs84_to_tile_index(lon2, lat2) == tile_index2
-    @test getraster(SRTM, bounds = (lon1, lat1, lon2, lat2)) == reshape([raster_path1, raster_path2], 1, 2)
+    @test getraster(SRTM; bounds = (lon1, lat1, lon2, lat2)) == reshape([raster_path1, raster_path2], 1, 2)
 end


### PR DESCRIPTION
This is a first attempt at adding the SRTM dataset

Some notes on the implementation:

- The code uses a mirror of SRTM data from [https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/](https://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/)

- The SRTM dataset is different from the currently implemented datasets:  
    - It has 5x5 degree tiles
    - It's around 400GB (uncompressed)

To handle these constraints, `getraster` takes a bounds argument for selecting the dataset region to download. When called with the bounds argument, this method also returns a matrix of strings with the appropriate tile paths.

TODO:
Need to propose changes so that `Raster(SRTM, bounds, ...)` from `Rasters.jl` can be implemented