### PR TITLE
Small fixes for MODIS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently sources include :
 | AWAP      | http://www.bom.gov.au/jsp/awap/index.jsp | Complete                             |
 | ALWB      | http://www.bom.gov.au/water/landscape/   | Complete                             |
 | SRTM      | https://www2.jpl.nasa.gov/srtm/          | Complete                             |
-| MODIS     | https://modis.ornl.gov |     In development |
+| MODIS     | https://modis.ornl.gov |     Complete (beta) |
 
 Please open an issue if you need more datasets added, or (even better) open a pull request 
 following the form of the other datasets where possible.

--- a/src/modis/utilities.jl
+++ b/src/modis/utilities.jl
@@ -196,6 +196,8 @@ function process_subset(T::Type{<:ModisProduct}, subset::Vector{Any}, pars::Name
         
         mat = permutedims(reshape(subset[i]["data"], (ncols, nrows)))
 
+        mkpath(dirname(filepath)) # prepare directories
+
         if !isfile(filepath)
             @info "Creating raster file $(basename(filepath)) in $(dirname(filepath))"
             write_ascii(filepath, mat; ncols = ncols, nrows = nrows, nodatavalue = -3000.0, pars...)

--- a/src/modis/utilities.jl
+++ b/src/modis/utilities.jl
@@ -196,7 +196,7 @@ function process_subset(T::Type{<:ModisProduct}, subset::Vector{Any}, pars::Name
         
         mat = permutedims(reshape(subset[i]["data"], (ncols, nrows)))
 
-        mkpath(dirname(filepath)) # prepare directories
+        mkpath(dirname(filepath)) # prepare directories if they dont exist
 
         if !isfile(filepath)
             @info "Creating raster file $(basename(filepath)) in $(dirname(filepath))"

--- a/src/modis/utilities.jl
+++ b/src/modis/utilities.jl
@@ -209,7 +209,7 @@ function process_subset(T::Type{<:ModisProduct}, subset::Vector{Any}, pars::Name
 
         if !isfile(filepath)
             @info "Creating raster file $(basename(filepath)) in $(dirname(filepath))"
-            write_ascii(filepath, mat; ncols = ncols, nrows = nrows, nodatavalue = -9999.0, pars...)
+            write_ascii(filepath, mat; ncols = ncols, nrows = nrows, nodatavalue = -3000.0, pars...)
         else
             @info "Raster file $(basename(filepath)) already exists in $(dirname(filepath))"
         end

--- a/src/modis/utilities.jl
+++ b/src/modis/utilities.jl
@@ -193,19 +193,8 @@ function process_subset(T::Type{<:ModisProduct}, subset::Vector{Any}, pars::Name
         band = subset[i]["band"]
 
         filepath = rasterpath(T, band; lat = pars[:yll], lon = pars[:xll], date = date)
-
-        mat = Matrix{Float32}(undef, nrows, ncols)
-
-        # fill matrix row by row
-        count = 1
-        for c = 1:ncols
-            for r = 1:nrows
-                mat[r, c] = float(subset[i]["data"][count])
-                count += 1
-            end
-        end
-
-        mkpath(dirname(filepath))
+        
+        mat = permutedims(reshape(subset[i]["data"], (ncols, nrows)))
 
         if !isfile(filepath)
             @info "Creating raster file $(basename(filepath)) in $(dirname(filepath))"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,6 @@ end
 @time @safetestset "worldclim weather" begin include("worldclim-weather.jl") end
 # SRTM SSL certs have expired
 # @time @safetestset "srtm" begin include("srtm.jl") end
-@time @safetestset "modis interface" begin include("modis-interface.jl") end
 @time @safetestset "modis utilities" begin include("modis-utilities.jl") end
 @time @safetestset "modis product info" begin include("modis-products.jl") end
+@time @safetestset "modis interface" begin include("modis-interface.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,6 @@ end
 @time @safetestset "worldclim weather" begin include("worldclim-weather.jl") end
 # SRTM SSL certs have expired
 # @time @safetestset "srtm" begin include("srtm.jl") end
+@time @safetestset "modis interface" begin include("modis-interface.jl") end
 @time @safetestset "modis utilities" begin include("modis-utilities.jl") end
 @time @safetestset "modis product info" begin include("modis-products.jl") end
-@time @safetestset "modis interface" begin include("modis-interface.jl") end


### PR DESCRIPTION
Hello :)

I found out that the current version of the MODIS data source handled non-square rasters *very badly*. It also mixed up latitude and longitude. 
This was caused by my way of building a data matrix from the results of the request : it is now fixed.

I also changed the default missingdata value to -3000, used by many MODIS datasets.
