### PR TITLE
Docstring overhaul

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,47 +25,36 @@ RasterDataSources.RasterDataSource
 
 ```@docs
 ALWB
-getraster(T::Type{<:ALWB}, layers::Union{Tuple,Symbol}; date)
 ```
 
 ## AWAP
 
 ```@docs
 AWAP
-getraster(T::Type{AWAP}, layer::Union{Tuple,Symbol}; date)
 ```
 
 ## CHELSA
 
 ```@docs
 CHELSA
-getraster(T::Type{CHELSA{BioClim}}, layer::Union{Tuple,Int,Symbol})
-getraster(T::Type{<:CHELSA{<:Future{Climate}}}, layers::Union{Tuple,Symbol}; date, month)
 ```
 
 ## EarthEnv
 
 ```@docs
 EarthEnv
-getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers::Union{Tuple,Symbol}; res)
-getraster(T::Type{EarthEnv{LandCover}}, layers::Union{Tuple,Int,Symbol}; res)
 ```
 
 ## WorldClim
 
 ```@docs
 WorldClim
-getraster(T::Type{WorldClim{BioClim}}, layers::Union{Tuple,Int,Symbol}; res)
-getraster(T::Type{WorldClim{Weather}}, layers::Union{Tuple,Symbol}; date)
-getraster(T::Type{WorldClim{Climate}}, layers::Union{Tuple,Symbol}; month, res)
-getraster(T::Type{WorldClim{Elevation}}, layers::Union{Tuple,Symbol}; month, res)
 ```
 
 ## MODIS
 
 ```@docs
 MODIS
-getraster(T::Type{<:ModisProduct})
 ModisProduct
 RasterDataSources.layerkeys(T::Type{<:ModisProduct})
 ```
@@ -75,6 +64,7 @@ RasterDataSources.layerkeys(T::Type{<:ModisProduct})
 ```@docs
 RasterDataSources.RasterDataSet
 BioClim
+BioClimPlus
 Climate
 Weather
 Elevation

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -41,7 +41,6 @@ export Values, Deciles
 
 export getraster
 
-include("interface.jl")
 include("types.jl")
 include("shared.jl")
 
@@ -71,6 +70,8 @@ include("modis/shared.jl")
 include("modis/products.jl")
 include("modis/utilities.jl")
 include("modis/examples.jl")
+
+include("interface.jl")
 
 for model in [CMIP5_MODELS; CMIP6_MODELS]
     symb = nameof(model)

--- a/src/alwb/alwb.jl
+++ b/src/alwb/alwb.jl
@@ -48,7 +48,29 @@ annual resolutions, and as `Values` or relative `Deciles`.
 
 `getraster` for `ALWB` must use a `date` keyword to specify the date to download.
 
-See the [`getraster`](@ref) docs for implementation details.
+# Usage with `getraster`
+    getraster(source::Type{<:ALWB{Union{Deciles,Values},Union{Day,Month,Year}}}, [layer]; date)
+
+Download `ALWB` weather data as values or deciles with timesteps of `Day`, `Month` or `Year`.
+
+# Arguments
+- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(layers(ALWB))`. Without a 
+    `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
+
+# Keywords
+- `date`: a `DateTime`, `AbstractVector` of `DateTime` or a `Tuple` of start and end dates.
+    For multiple dates, a `Vector` of multiple filenames will be returned.
+    ALWB is available with a daily, monthly, and yearly, timestep.
+
+# Example
+This will return the file containing annual averages, including your date:
+
+```julia
+julia> getraster(ALWB{Values,Year}, :ss_pct; date=Date(2001, 2))
+"/your/RASTERDATASOURCES_PATH/ALWB/values/month/ss_pct.nc"
+```
+
+Returns the filepath/s of the downloaded or pre-existing files.
 """ ALWB
 
 # http://www.bom.gov.au/jsp/awra/thredds/fileServer/AWRACMS/values/day/rain_day_2017.nc
@@ -83,32 +105,6 @@ See the [`getraster`](@ref) docs for implementation details.
 # DeepDrainage = "dd"
 
 
-"""
-    getraster(source::Type{<:ALWB{Union{Deciles,Values},Union{Day,Month,Year}}}, [layer]; date)
-
-Download [`ALWB`](@ref) weather data from 
-[www.bom.gov.au/water/landscape](http://www.bom.gov.au/water/landscape) as values or 
-deciles with timesteps of `Day`, `Month` or `Year`.
-
-# Arguments
-- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(layers(ALWB))`. Without a 
-    `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keywords
-- `date`: a `DateTime`, `AbstractVector` of `DateTime` or a `Tuple` of start and end dates.
-    For multiple dates, a `Vector` of multiple filenames will be returned.
-    ALWB is available with a daily, monthly, and yearly, timestep.
-
-# Example
-This will return the file containing annual averages, including your date:
-
-```julia
-julia> getraster(ALWB{Values,Year}, :ss_pct; date=Date(2001, 2))
-"/your/RASTERDATASOURCES_PATH/ALWB/values/month/ss_pct.nc"
-```
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 function getraster(T::Type{<:ALWB}, layers::Union{Tuple,Symbol}; date)
      _getraster(T, layers, date)
 end

--- a/src/awap/awap.jl
+++ b/src/awap/awap.jl
@@ -14,34 +14,17 @@ Daily weather data from the Australian Water Availability Project, developed by 
 
 See: [www.csiro.au/awap](http://www.csiro.au/awap/)
 
-The available layers are: `$(layers(AWAP))`.
-""" AWAP
-
-const AWAP_PATHSEGMENTS = (
-    solar = ("solar", "solarave", "daily"),
-    rainfall = ("rainfall", "totals", "daily"),
-    vprpress09 = ("vprp", "vprph09", "daily"),
-    vprpress15 = ("vprp", "vprph15", "daily"),
-    tmin = ("temperature", "minave", "daily"),
-    tmax = ("temperature", "maxave", "daily"),
-)
-# Add ndvi monthly?  ndvi, ndviave, month
-
-"""
-    getraster(source::Type{AWAP}, [layer]; date)
-
-Download data from the [`AWAP`](@ref) weather dataset, from
-[www.csiro.au/awap](http://www.csiro.au/awap/). 
-
 The AWAP dataset contains ASCII `.grid` files.
 
-# Arguments
+# Usage with `getraster`
+    getraster(source::Type{AWAP}, [layer]; date)
 
-- `layer` `Symbol` or `Tuple` of `Symbol` for `layer`s in `$(layers(AWAP))`. Without a 
+
+# Arguments
+- `layer`: `Symbol` or `Tuple` of `Symbol` for `layer`s in `$(layers(AWAP))`. Without a 
     `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
 
 # Keywords
-
 - `date`: a `DateTime`, `AbstractVector` of `DateTime` or a `Tuple` of start and end dates.
     For multiple dates, A `Vector` of multiple filenames will be returned.
     AWAP is available with a daily timestep.
@@ -61,7 +44,18 @@ julia> getraster(AWAP, :rainfall; date=Date(2001, 1, 1):Day(1):Date(2001, 1, 31)
 ```
 
 Returns the filepath/s of the downloaded or pre-existing files.
-"""
+""" AWAP
+
+const AWAP_PATHSEGMENTS = (
+    solar = ("solar", "solarave", "daily"),
+    rainfall = ("rainfall", "totals", "daily"),
+    vprpress09 = ("vprp", "vprph09", "daily"),
+    vprpress15 = ("vprp", "vprph15", "daily"),
+    tmin = ("temperature", "minave", "daily"),
+    tmax = ("temperature", "maxave", "daily"),
+)
+# Add ndvi monthly?  ndvi, ndviave, month
+
 getraster(T::Type{AWAP}, layer::Union{Tuple,Symbol}; date) = _getraster(T, layer, date)
 
 getraster_keywords(::Type{<:AWAP}) = (:date,)

--- a/src/chelsa/bioclim.jl
+++ b/src/chelsa/bioclim.jl
@@ -3,21 +3,6 @@ layers(::Type{CHELSA{BioClimPlus}}) = layers(BioClimPlus)
 layerkeys(::Type{CHELSA{BioClim}}, args...) = layerkeys(BioClim, args...)
 layerkeys(::Type{CHELSA{BioClimPlus}}, args...) = layerkeys(BioClimPlus, args...)
 
-"""
-    getraster(source::Type{CHELSA{BioClim}}, [layer]; version = 2, [patch]) => Union{Tuple,String}
-
-Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https://chelsa-climate.org/).
-
-# Arguments
-- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(BioClim))`, 
-    or `Symbol`s form `$(layerkeys(BioClim))`. Without a `layer` argument, all layers
-    will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keyword arguments
-$CHELSA_KEYWORDS
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 getraster(
     T::Type{CHELSA{BioClim}}, 
     layer::Union{Tuple,Int,Symbol}; 
@@ -62,20 +47,6 @@ rasterurl(T::Type{CHELSA{BioClim}}, layer::Integer; version = 2, patch = latest_
     joinpath(rasterurl(T; version), "bio", rastername(T, layer; version, patch))
 
 ### Bioclim+
-"""
-    getraster(source::Type{CHELSA{BioClim}}, [layer]; version = 2, [patch]) => Union{Tuple,String}
-
-Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https://chelsa-climate.org/).
-
-# Arguments
-- `layer`: iterable of `Symbol`s from `$(layerkeys(BioClimPlus))`. Without a `layer` argument, all layers
-    will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keyword arguments
-$CHELSA_KEYWORDS
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 getraster(
     T::Type{CHELSA{BioClimPlus}}, 
     layer::Union{Tuple,Int,Symbol}; 

--- a/src/chelsa/climate.jl
+++ b/src/chelsa/climate.jl
@@ -1,18 +1,5 @@
 layers(::Type{CHELSA{Climate}}) = (:clt, :cmi, :hurs, :ncdf, :pet, :pr, :rsds, :sfcWind, :tas, :tasmax, :tasmin, :vpd)
 
-"""
-    getraster(T::Type{CHELSA{Climate}}, [layer::Union{Tuple,Symbol}]; month) => Vector{String}
-
-Download [`CHELSA`](@ref) [`Climate`](@ref) data. 
-
-# Arguments
-- `layer` `Symbol` or `Tuple` of `Symbol` from `$(layers(CHELSA{Climate}))`.
-
-# Keywords
-- `month`: `Integer` or `AbstractArray` of `Integer`. Chosen from `1:12`.
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 function getraster(T::Type{CHELSA{Climate}}, layers::Union{Tuple,Symbol}; month)
     _getraster(T, layers, month)
 end

--- a/src/chelsa/future.jl
+++ b/src/chelsa/future.jl
@@ -12,30 +12,6 @@ date_range(::Type{<:CHELSA{<:Future{<:Any,CMIP5}}}) = (Date(2041), Date(2080))
 date_step(::Type{<:CHELSA{<:Future{<:Any,CMIP6}}}) = Year(30) 
 date_range(::Type{<:CHELSA{<:Future{<:Any,CMIP6}}}) = (Date(1981), Date(2100)) 
 
-"""
-    getraster(T::Type{CHELSA{Future{BioClim}}}, [layer]; date) => String
-
-Download CHELSA [`BioClim`](@ref) data, choosing layers from: `$(layers(CHELSA{BioClim}))`.
-
-See the docs for [`Future`](@ref) for model choices.
-
-Without a layer argument, all layers will be downloaded, and a `NamedTuple` of paths 
-returned.
-
-## Keywords
-
-- `date`: a `Date` or `DateTime` object, a Vector, or Tuple of start/end dates.
-    Note that CHELSA CMIP5 only has two datasets, for the periods 2041-2060 and
-    2061-2080. CMIP6 has datasets for the periods 2011-2040, 2041-2070, and 2071-2100.
-    Dates must fall within these ranges.
-
-## Example
-```julia
-using RasterDataSources, Dates
-getraster(CHELSA{Future{BioClim, CMIP6, GFDLESM4, SSP370}}, 1, date = Date(2050))
-```
-
-"""
 function getraster(
     T::Type{<:CHELSA{<:Future{BioClim}}}, layers::Union{Tuple,Int,Symbol}; date
 )
@@ -44,25 +20,6 @@ end
 
 getraster_keywords(::Type{<:CHELSA{<:Future{BioClim}}}) = (:date,)
 
-"""
-    getraster(T::Type{CHELSA{Future{BioClimPlus}}}, [layer]; date) => String
-
-Download CHELSA [`BioClimPlus`](@ref) data, choosing layers from: `$(layers(CHELSA{BioClimPlus}))`.
-
-See the docs for [`Future`](@ref) for model choices.
-
-Without a layer argument, all layers will be downloaded, and a `NamedTuple` of paths 
-returned.
-
-## Keywords
-
-- `date`: a `Date` or `DateTime` object, a Vector, or Tuple of start/end dates.
-    Note that CHELSA CMIP5 only has two datasets, for the periods 2041-2060 and
-    2061-2080. CMIP6 has datasets for the periods 2011-2040, 2041-2070, and 2071-2100.
-    Dates must fall within these ranges.
-
-## Example
-"""
 function getraster(
     T::Type{<:CHELSA{<:Future{BioClimPlus}}}, layers::Union{Tuple,Int,Symbol}; date
 )
@@ -72,29 +29,6 @@ end
 getraster_keywords(::Type{<:CHELSA{<:Future{BioClimPlus}}}) = (:date,)
 
 
-"""
-    getraster(T::Type{CHELSA{Future{Climate}}}, [layer]; date, month) => String
-
-Download CHELSA [`Climate`](@ref) data, choosing layers from: `$(layers(CHELSA{BioClim}))`.
-
-See the docs for [`Future`](@ref) for model choices.
-
-Without a layer argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
-
-## Keywords
-
-- `date`: a `Date` or `DateTime` object, a Vector, or Tuple of start/end dates.
-    Note that CHELSA CMIP5 only has two datasets, for the periods 2041-2060 and
-    2061-2080. CMIP6 has datasets for the periods 2011-2040, 2041-2070, and 2071-2100.
-    Dates must fall within these ranges.
-- `month`: the month of the year, from 1 to 12, or a array or range of months like `1:12`.
-
-## Example
-```
-using Dates, RasterDataSources
-getraster(CHELSA{Future{Climate, CMIP6, GFDLESM4, SSP370}}, :prec; date = Date(2050), month = 1)
-```
-"""
 function getraster(
     T::Type{<:CHELSA{<:Future{Climate}}}, layers::Union{Tuple,Symbol}; date, month
 )

--- a/src/chelsa/shared.jl
+++ b/src/chelsa/shared.jl
@@ -1,12 +1,3 @@
-"""
-    CHELSA{Union{BioClim,BioClimPlus,Climate,<:Future}} <: RasterDataSource
-
-Data from CHELSA, currently implements the `BioClim` `BioClimPlus`, and `Climate`
-variables for current and future conditions. 
-
-See: [chelsa-climate.org](https://chelsa-climate.org/) for the dataset,
-and the [`getraster`](@ref) docs for implementation details.
-"""
 struct CHELSA{X} <: RasterDataSource end
 
 rasterpath(::Type{CHELSA}) = joinpath(rasterpath(), "CHELSA")
@@ -30,11 +21,6 @@ function latest_patch(::Type{<:CHELSA}, v)
         CHELSA_invalid_version(v)
     end
 end
-
-const CHELSA_KEYWORDS = """
-- `version`: `Integer` indicating the CHELSA version, currently either `1` or `2`.
-- `patch`: `Integer` indicating the CHELSA patch number. Defaults to the latest patch (V1.2 and V2.1)
-"""
 
 CHELSA_invalid_version(v, valid_versions = [1,2]) = 
         throw(ArgumentError("Version $v is not available for CHELSA. Available versions: $valid_versions."))

--- a/src/earthenv/habitatheterogeneity.jl
+++ b/src/earthenv/habitatheterogeneity.jl
@@ -27,20 +27,6 @@ const heterogeneity_lookup = (
 
 heterogeneity_layer(x::Symbol) = heterogeneity_lookup[Symbol(lowercase(string(x)))]
 
-"""
-    getraster(source::Type{EarthEnv{HabitatHeterogeneity}}, [layer]; res="25km")
-
-Download [`EarthEnv`](@ref) habitat heterogeneity data.
-
-# Arguments
-- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(layers(EarthEnv{HabitatHeterogeneity}))`.
-    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keywords
-- `res`: `String` chosen from `$(resolutions(EarthEnv{HabitatHeterogeneity}))`, defaulting to "25km".
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 function getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, layers::Union{Tuple,Symbol};
     res::String=defres(T)
 )

--- a/src/earthenv/landcover.jl
+++ b/src/earthenv/landcover.jl
@@ -20,23 +20,6 @@ const landcover_lookup = (
     open_water = 12,
 )
 
-"""
-    getraster(T::Type{EarthEnv{LandCover}}, [layer]; discover=false) => Union{Tuple,String}
-
-Download [`EarthEnv`](@ref) landcover data.
-
-# Arguments
-
-- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(EarthEnv{LandCover}))`,
-    or `Symbol`s from `$(layerkeys(EarthEnv{LandCover}))`. Without a `layer` argument,
-    all layers will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keywords
-
-- `discover::Bool`: whether to download the dataset that integrates the DISCover model.
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 function getraster(T::Type{<:EarthEnv{<:LandCover}}, layers::Union{Tuple,Int,Symbol})
     _getraster(T, layers)
 end

--- a/src/earthenv/shared.jl
+++ b/src/earthenv/shared.jl
@@ -1,10 +1,3 @@
-"""
-    EarthEnv{Union{HabitatHeterogeneity,LandCover}} <: RasterDataSource
-
-Data from the `EarthEnv` including `HabitatHeterogeneity` and `LandCover`
-
-See: [www.earthenv.org](http://www.earthenv.org/)
-"""
 struct EarthEnv{X} <: RasterDataSource end
 
 rasterpath(::Type{EarthEnv}) = joinpath(rasterpath(), "EarthEnv")

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -161,6 +161,12 @@ See: [www.worldclim.org](https://www.worldclim.org)
 - `date`: a `Date` or `DateTime` object, a `Vector` of dates, or `Tuple` of start/end dates.
     `WorldClim{Weather}` is available with a daily timestep. Future data is available in 20-year intervals from 2021 to 2100.
 
+## Examples
+```julia
+using RasterDataSources, Dates
+bio_current = getraster(WorldClim{BioClim}, res = "5m")
+bio_future = getraster(WorldClim{Future{BioClim, CMIP6, GFDL_ESM4, SSP370}}, date = Date(2050), res = "5m")
+```
 """
 WorldClim
 
@@ -227,6 +233,11 @@ Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https
     2061-2080. CMIP6 has datasets for the periods 2011-2040, 2041-2070, and 2071-2100.
     Dates must fall within these ranges.
     
+## Example
+```julia
+using RasterDataSources, Dates
+getraster(CHELSA{Future{BioClim, CMIP6, GFDL_ESM4, SSP370}}, 1, date = Date(2050))
+```
 """
 CHELSA
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -10,11 +10,10 @@ for a `Tuple` of layers.
 `getraster` provides a standardised interface to download data sources,
 and return the filename/s of the selected files.
 
-RasterDataSources.jl aims to standardise an API for downloading many kinds of raster files
-from many sources, that can be wrapped by other packages (such as Rasters.jl and
-SimpleSDMLayers.jl) in a simple, regular way. As much as possible it will move towards
-having less source-specific keywords wherever possible. Similar datasets will behave in the
-same way so that they can be used interchangeably in the same code.
+`getraster` can be called with any `RasterDataSource`. See the docstrings of these types
+for the specific keywords and arguments. `RasterDataSource` with documented `getraster` usage are
+[`WorldClim`](@ref), [`EarthEnv`](@ref), [`CHELSA`](@ref), [`AWAP`](@ref), [`ALWB`](@ref), 
+and [`MODIS`](@ref). All these implementations follow the template specified below.
 
 # Arguments
 
@@ -53,18 +52,8 @@ Where `date` and `month` keywords coexist, `Vector{Vector{String}}` of
 `Vector{Vector{NamedTuple}}` is the result. `date` ranges are always
 the outer `Vector`, `month` the inner `Vector` with `layer` tuples as
 the inner `NamedTuple`. No other keywords can be `Vector`.
-
-This schema may be added to in future for datasets with additional axes,
-but should not change for the existing `RasterDataSource` types.
 """
 function getraster end
-
-"""
-    getraster(T::Type, layers::Union{Tuple,Int,Symbol}; kw...)
-
-"""
-function getraster end
-
 
 # Not exported, but relatively consistent and stable
 # These should be used for consistency accross all sources
@@ -135,3 +124,107 @@ Arguments are the same as for `getraster` where possible.
 Returns a URIs.jl `URI` or mulitiple `URI`s.
 """
 function zipurl end
+
+"""
+    WorldClim{Union{BioClim,Climate,Elevation,Weather,<:Future}} <: RasterDataSource
+
+Data from WorldClim datasets, either [`BioClim`](@ref), [`Climate`](@ref), 
+[`Weather`](@ref), [`Climate`](@ref), or [`Future`](@ref) variables for current and future conditions.
+
+Future variables are available for `BioClim` and `Climate` data. See the docstring of `Future` for available model choices
+    and implementation details.
+
+See: [www.worldclim.org](https://www.worldclim.org)
+
+# Usage with `getraster`
+    getraster(T::Type{WorldClim{BioClim}}, [layer::Union{Tuple,Int,Symbol}]; res)
+    getraster(T::Type{WorldClim{Climate}}, [layer::Union{Tuple,Symbol}]; month, res)
+    getraster(T::Type{WorldClim{Elevation}}; res)
+    getraster(T::Type{WorldClim{Weather}}, [layer::Union{Tuple,Symbol}]; date)
+    getraster(T::Type{WorldClim{Future}}, [layer]; date, res) => String
+
+## Arguments
+
+- `layer`: `Integer`, `Symbol` or tuple/range of these. Without a `layer` argument, all layers
+    will be downloaded, and a `NamedTuple` of paths returned. Available layers are:
+    - `BioClim`: Integers $(first(layers(BioClim))) to $(last(layers(BioClim))) 
+        or Symbols :$(first(layerkeys(BioClim))) to :$(last(layerkeys(BioClim)))
+    - `Climate`: $(layers(WorldClim{Climate}))
+    - `Weather`: $(layers(WorldClim{Weather}))
+    - `Future{Climate}`: $(layers(WorldClim{Future{Climate}}))
+
+## Keywords
+
+- `res`: `String` chosen from $(resolutions(WorldClim{BioClim})), "10m" by default.
+- `month`: `Integer` or `AbstractArray` of `Integer`. Chosen from `1:12`.
+- `date`: a `Date` or `DateTime` object, a `Vector` of dates, or `Tuple` of start/end dates.
+    `WorldClim{Weather}` is available with a daily timestep. Future data is available in 20-year intervals from 2021 to 2100.
+
+"""
+WorldClim
+
+"""
+    EarthEnv{Union{HabitatHeterogeneity,LandCover}} <: RasterDataSource
+
+Data from the `EarthEnv` including `HabitatHeterogeneity` and `LandCover`
+
+See: [www.earthenv.org](http://www.earthenv.org/)
+
+# Usage with `getraster`
+    getraster(T::Type{EarthEnv{HabitatHeterogeneity}}, [layer]; res="25km")
+    getraster(T::Type{EarthEnv{LandCover}}, [layer]; discover=false)
+
+Download [`EarthEnv`](@ref) habitat heterogeneity data.
+
+# Arguments
+- `layer`: `Integer`, `Symbol` or tuple/range of these. Without a `layer` argument, all layers
+    will be downloaded, and a `NamedTuple` of paths returned. Available layers are:
+    - `HabitatHeterogeneity`: $(layers(EarthEnv{HabitatHeterogeneity}))
+    - `LandCover`: Integers $(first(layers(EarthEnv{LandCover}))) to $(last(layers(EarthEnv{LandCover}))) or 
+        Symbols $(layerkeys(EarthEnv{LandCover}))
+
+# Keywords
+- `res`: `String` chosen from `$(resolutions(EarthEnv{HabitatHeterogeneity}))`, defaulting to "25km".
+- `discover::Bool`: whether to download the dataset that integrates the DISCover model.
+
+Returns the filepath/s of the downloaded or pre-existing files.
+"""
+EarthEnv
+
+"""
+    CHELSA{Union{BioClim,BioClimPlus,Climate,<:Future}} <: RasterDataSource
+
+Data from CHELSA, currently implements the `BioClim`, `BioClimPlus`, and `Climate`
+variables for current and future conditions. 
+
+See: [chelsa-climate.org](https://chelsa-climate.org/) for the dataset,
+and the [`getraster`](@ref) docs for implementation details.
+
+# Usage with `getraster`
+    getraster(source::Type{CHELSA{BioClim}}, [layer]; [version], [patch])
+    getraster(source::Type{CHELSA{BioClimPlus}}, [layer]; [version], [patch])
+    getraster(T::Type{CHELSA{Climate}}, [layer]; month)
+    getraster(T::Type{CHELSA{Future{BioClim}}}, [layer]; date
+    getraster(T::Type{CHELSA{Future{Climate}}}, [layer]; date, month)
+
+Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https://chelsa-climate.org/).
+
+## Arguments
+- `layer`: `Integer`, `Symbol` or tuple/range of these. Without a `layer` argument, all layers
+    will be downloaded, and a `NamedTuple` of paths returned. Available layers are:
+    - `BioClim`: Integers $(first(layers(BioClim))) to $(last(layers(BioClim))) or 
+        Symbols :$(first(layerkeys(BioClim))) to :$(last(layerkeys(BioClim)))
+    - `BioClimPlus`: Includes `BioClim` layers and many additional layers. See `RasterDataSources.layers(BioClimPlus)`.
+    - `Climate`: $(layers(CHELSA{Climate}))
+
+## Keyword arguments
+- `version`: `Integer` indicating the CHELSA version, currently either `1` or `2`. Defaults to 2.
+- `patch`: `Integer` indicating the CHELSA patch number. Defaults to the latest patch (V1.2 and V2.1)
+- `month`: `Integer` or `AbstractArray` of `Integer`. Chosen from `1:12`.
+- `date`: a `Date` or `DateTime` object, a Vector, or Tuple of start/end dates.
+    Note that CHELSA CMIP5 only has two datasets, for the periods 2041-2060 and
+    2061-2080. CMIP6 has datasets for the periods 2011-2040, 2041-2070, and 2071-2100.
+    Dates must fall within these ranges.
+    
+"""
+CHELSA

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -150,6 +150,7 @@ See: [www.worldclim.org](https://www.worldclim.org)
     - `BioClim`: Integers $(first(layers(BioClim))) to $(last(layers(BioClim))) 
         or Symbols :$(first(layerkeys(BioClim))) to :$(last(layerkeys(BioClim)))
     - `Climate`: $(layers(WorldClim{Climate}))
+    - `Elevation`: Only has a single layer, :elev
     - `Weather`: $(layers(WorldClim{Weather}))
     - `Future{Climate}`: $(layers(WorldClim{Future{Climate}}))
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -229,3 +229,48 @@ Download [`CHELSA`](@ref) [`BioClim`](@ref) data from [chelsa-climate.org](https
     
 """
 CHELSA
+
+"""
+    Future{<:RasterDataSet,<:CMIPphase,<:ClimateModel,<:ClimateScenario}
+
+Future climate datasets specified with a dataset, phase, model, and scenario.
+
+## Type Parameters
+
+#### `RasterDataSet`
+
+Currently [`BioClim`](@ref) and [`Climate`](@ref) are implemented
+for [`CHELSA`](@ref) and [`WorldClim`](@ref). Future WorldClim is only available 
+for CMIP6.
+
+#### `CMIPphase`
+
+Can be either [`CMIP5`](@ref) or [`CMIP6`](@ref).
+
+#### `ClimateModel`
+
+Climate models can be chosen from: 
+
+`$(join(CMIP5_MODELS, "`,  `"))` for `CMIP5`;
+
+`$(join(CMIP6_MODELS, "`,  `"))` for `CMIP6`;"
+
+#### `ClimateScenario`
+
+CMIP5 Climate scenarios are all [`RepresentativeConcentrationPathway`](@ref)
+and can be chosen from: `RCP26`, `RCP45`, `RCP60`, `RCP85`
+
+CMIP6 Climate scenarios are all [`SharedSocioeconomicPathway`](@ref) and
+can be chosen from: `SSP126`, `SSP245`, `SSP370`, `SSP585`
+
+However, note that not all climate scenarios are available for all models.
+
+## Example
+
+```jldoctest future
+using RasterDataSources
+datasource = CHELSA{Future{BioClim, CMIP5, GFDL_ESM4, SSP370}}
+```
+
+"""
+Future

--- a/src/modis/shared.jl
+++ b/src/modis/shared.jl
@@ -4,6 +4,41 @@
 MODIS/VIIRS Land Product Database. Vegetation indices, surface reflectance, and more land cover data. Data from [`ModisProduct`](@ref)s datasets. 
 
 See: [modis.ornl.gov](https://modis.ornl.gov/)
+
+# Usage with `getraster`
+    getraster(T::Union{Type{<:ModisProduct}, Type{MODIS{X}}}, [layer::Union{Tuple,AbstractVector,Integer, Symbol}]; kwargs...) => Union{String, AbstractVector, NamedTuple}
+
+Download [`MODIS`](@ref) data for a given [`ModisProduct`](@ref) as ASCII raster(s).
+
+# Arguments
+
+- `layer`: `Integer` or tuple/range of `Integer` or `Symbol`s. Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
+
+Available layers for a given product can be looked up using [`RasterDataSources.layerkeys(T::Type{<:ModisProduct})`](@ref).
+
+# Keywords
+
+- `lat` and `lon`: Coordinates in decimal degrees of the approximate center of the raster. The MODIS API will try to match its pixel grid system as close as possible to those coordinates.
+
+- `km_ab` and `km_lr`: Half-width and half-height of the raster in kilometers (kilometers above/below and left/right). Currently only `Integer` values are supported, up to 100.
+
+- `date`: `String`, `Date`, `DateTime`, `AbstractVector` of dates or `Tuple` of a start and end date for the request. `String`s should be in format YYYY-MM-DD but can be in similar formats as long as they are comprehensible by `Dates.Date`. The available date interval for MODIS is 16 days, reset every first of January.
+
+# Example
+
+Download 250m NDVI in the western part of Britanny, France, from winter to late spring, 2002:
+
+```julia
+julia> getraster(MOD13Q1, :NDVI; lat = 48.25, lon = -4, km_ab = 50, km_lr = 50, date = (Date(2002,1,1), Date(2002,6,1)))
+
+    10-element Vector{String}:
+    "/your/path/MODIS/MOD13Q1/250m_16_days_NDVI/47.8313_-4.5899_2002-01-01.asc"
+    ...
+    "/your/path/MODIS/MOD13Q1/250m_16_days_NDVI/47.8313_-4.5899_2002-05-25.asc"
+```
+
+Will attempt to download several files, one for each date and layer combination, and returns the filepath/s of the downloaded or pre-existing files. Coordinates in the file names correspond to the lower-left corner of the raster.
+
 """
 struct MODIS{X} <: RasterDataSource end
 
@@ -66,40 +101,6 @@ end
 
 getraster_keywords(::Type{<:Union{MODIS,ModisProduct}}) = (:lat, :lon, :km_ab, :km_lr, :date, :end)
 
-"""
-    getraster(T::Union{Type{<:ModisProduct}, Type{MODIS{X}}}, [layer::Union{Tuple,AbstractVector,Integer, Symbol}]; kwargs...) => Union{String, AbstractVector, NamedTuple}
-
-Download [`MODIS`](@ref) data for a given [`ModisProduct`](@ref) as ASCII raster(s).
-
-# Arguments
-
-- `layer`: `Integer` or tuple/range of `Integer` or `Symbol`s. Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
-
-Available layers for a given product can be looked up using [`RasterDataSources.layerkeys(T::Type{<:ModisProduct})`](@ref).
-
-# Keywords
-
-- `lat` and `lon`: Coordinates in decimal degrees of the approximate center of the raster. The MODIS API will try to match its pixel grid system as close as possible to those coordinates.
-
-- `km_ab` and `km_lr`: Half-width and half-height of the raster in kilometers (kilometers above/below and left/right). Currently only `Integer` values are supported, up to 100.
-
-- `date`: `String`, `Date`, `DateTime`, `AbstractVector` of dates or `Tuple` of a start and end date for the request. `String`s should be in format YYYY-MM-DD but can be in similar formats as long as they are comprehensible by `Dates.Date`. The available date interval for MODIS is 16 days, reset every first of January.
-
-# Example
-
-Download 250m NDVI in the western part of Britanny, France, from winter to late spring, 2002:
-
-```julia
-julia> getraster(MOD13Q1, :NDVI; lat = 48.25, lon = -4, km_ab = 50, km_lr = 50, date = (Date(2002,1,1), Date(2002,6,1)))
-
-    10-element Vector{String}:
-    "/your/path/MODIS/MOD13Q1/250m_16_days_NDVI/47.8313_-4.5899_2002-01-01.asc"
-    ...
-    "/your/path/MODIS/MOD13Q1/250m_16_days_NDVI/47.8313_-4.5899_2002-05-25.asc"
-```
-
-Will attempt to download several files, one for each date and layer combination, and returns the filepath/s of the downloaded or pre-existing files. Coordinates in the file names correspond to the lower-left corner of the raster.
-"""
 function getraster(
     T::Type{<:ModisProduct},
     layer::Union{Tuple,Symbol,Int} = layerkeys(T);

--- a/src/types.jl
+++ b/src/types.jl
@@ -80,55 +80,6 @@ struct SSP245 <: SharedSocioeconomicPathway end
 struct SSP370 <: SharedSocioeconomicPathway end
 struct SSP585 <: SharedSocioeconomicPathway end
 
-"""
-    Future{<:RasterDataSet,<:CMIPphase,<:ClimateModel,<:ClimateScenario}
-
-Future climate datasets specified with a dataset, phase, model, and scenario.
-
-## Type Parameters
-
-#### `RasterDataSet`
-
-Currently [`BioClim`](@ref) and [`Climate`](@ref) are implemented
-for the [`CHELSA`](@ref) data source.
-
-#### `CMIPphase`
-
-Can be either [`CMIP5`](@ref) or [`CMIP6`](@ref).
-
-#### `ClimateModel`
-
-Climate models can be chosen from: 
-
-`$(join(CMIP5_MODELS, "`,  `"))` for `CMIP5`;
-
-`$(join(CMIP6_MODELS, "`,  `"))` for `CMIP6`;"
-
-#### `ClimateScenario`
-
-CMIP5 Climate scenarios are all [`RepresentativeConcentrationPathway`](@ref)
-and can be chosen from: `RCP26`, `RCP45`, `RCP60`, `RCP85`
-
-CMIP6 Climate scenarios are all [`SharedSocioeconomicPathway`](@ref) and
-can be chosen from: `SSP126`, `SSP245`, `SSP370`, `SSP585`
-
-However, note that not all climate scenarios are available for all models.
-
-## Example
-
-```jldoctest future
-using RasterDataSources
-dataset = Future{BioClim, CMIP5, BNUESM, RCP45}
-# output
-Future{BioClim, CMIP5, BNUESM, RCP45}
-```
-Currently `Future` is only implented for `CHELSA`
-
-```jldoctest future
-datasource = CHELSA{Future{BioClim, CMIP5, BNUESM, RCP45}}
-```
-
-"""
 struct Future{D<:RasterDataSet,C<:CMIPphase,M<:ClimateModel,S<:ClimateScenario} end
 
 _dataset(::Type{<:Future{D}}) where D = D

--- a/src/types.jl
+++ b/src/types.jl
@@ -151,10 +151,10 @@ These can also be accessed with `:bioX`, e.g. `:bio5`.
 They do not usually use `month` or `date` keywords, but may use
 `date` in past/future scenarios. 
 
-Currently implemented for WorldClim and CHELSA as `WorldClim{BioClim}`,
-`CHELSA{BioClim}` and `CHELSA{Future{BioClim, args..}}`.
+Currently implemented for WorldClim and CHELSA as `WorldClim{BioClim}`, `WorldClim{Future{BioClim}}`,
+`CHELSA{BioClim}`, `CHELSA{Future{BioClim, args..}}`.
 
-See the [`getraster`](@ref) docs for implementation details.
+See the [`CHELSA`](@ref) and [`WorldClim`](@ref) docs for implementation details.
 """
 struct BioClim <: RasterDataSet end
 
@@ -210,7 +210,7 @@ They do not usually use `month` or `date` keywords, but may use
 Currently implemented for CHELSA as `CHELSA{BioClim}` and `CHELSA{Future{BioClim, args..}}`,
 specifying layer names as `Symbol`s.
 
-See the [`getraster`](@ref) docs for implementation details.
+See the [`CHELSA`](@ref) docs for implementation details.
 """
 struct BioClimPlus <: RasterDataSet end
 
@@ -241,10 +241,10 @@ layers(::Type{Future{BioClimPlus}}) = BIOCLIMPLUS_LAYERS_FUTURE
 Climate datasets. These are usually months of the year, not specific dates,
 and use a `month` keyword in `getraster`. They also use `date` in past/future scenarios.
 
-Currently implemented for WorldClim and CHELSA as `WorldClim{Climate}`,
+Currently implemented for WorldClim and CHELSA as `WorldClim{Climate}`, `WorldClim{Future{Climate, args..}}`
 `CHELSA{Climate}` and `CHELSA{Future{Climate, args..}}`.
 
-See the [`getraster`](@ref) docs for implementation details.
+See the [`CHELSA`](@ref) and [`WorldClim`](@ref) docs for implementation details.
 """
 struct Climate <: RasterDataSet end
 
@@ -256,10 +256,9 @@ months(::Type{Climate}) = ntuple(identity, Val{12})
 Weather datasets. These are usually large time-series of specific dates,
 and use a `date` keyword in `getraster`.
 
-Currently implemented for WorldClim and CHELSA as `WorldClim{Weather}`,
-and `CHELSA{Weather}`
+Currently implemented for WorldClim as `WorldClim{Weather}`.
 
-See the [`getraster`](@ref) docs for implementation details.
+See the [`WorldClim`](@ref) docs for implementation details.
 """
 struct Weather <: RasterDataSet end
 
@@ -270,7 +269,7 @@ Elevation datasets.
 
 Currently implemented for WorldClim as `WorldClim{Elevation}`.
 
-See the [`getraster`](@ref) docs for implementation details.
+See the [`WorldClim`](@ref) docs for implementation details.
 """
 struct Elevation <: RasterDataSet end
 
@@ -279,9 +278,9 @@ struct Elevation <: RasterDataSet end
 
 Land-cover datasets.
 
-Currently implemented for EarthEnv as `EarchEnv{LandCover}`.
+Currently implemented for EarthEnv as `EarthEnv{LandCover}`.
 
-See the [`getraster`](@ref) docs for implementation details.
+See the [`EarthEnv`](@ref) docs for implementation details.
 """
 struct LandCover{X} <: RasterDataSet end
 
@@ -290,9 +289,9 @@ struct LandCover{X} <: RasterDataSet end
 
 Habitat heterogeneity datasets.
 
-Currently implemented for EarchEnv as `EarchEnv{HabitatHeterogeneity}`.
+Currently implemented for EarthEnv as `EarthEnv{HabitatHeterogeneity}`.
 
-See the [`getraster`](@ref) docs for implementation details.
+See the [`EarthEnv`](@ref) docs for implementation details.
 """
 struct HabitatHeterogeneity <: RasterDataSet end
 

--- a/src/worldclim/bioclim.jl
+++ b/src/worldclim/bioclim.jl
@@ -1,23 +1,6 @@
 layers(::Type{WorldClim{BioClim}}) = layers(BioClim)
 layerkeys(T::Type{WorldClim{BioClim}}, args...) = layerkeys(BioClim, args...)
 
-"""
-    getraster(T::Type{WorldClim{BioClim}}, [layer::Union{Tuple,AbstractVector,Integer}]; res::String="10m") => Union{Tuple,AbstractVector,String}
-
-Download [`WorldClim`](@ref) [`BioClim`](@ref) data.
-
-# Arguments
-
-- `layer`: `Integer` or tuple/range of `Integer` from `$(layers(BioClim))`. 
-    or `Symbol`s from `$(layerkeys(BioClim))`. Without a `layer` argument, all layers
-    will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keywords
-
-- `res`: `String` chosen from $(resolutions(WorldClim{BioClim})), "10m" by default.
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 function getraster(T::Type{WorldClim{BioClim}}, layers::Union{Tuple,Int,Symbol}; 
     res::String=defres(T)
 )

--- a/src/worldclim/climate.jl
+++ b/src/worldclim/climate.jl
@@ -1,20 +1,5 @@
 layers(::Type{WorldClim{Climate}}) = (:tmin, :tmax, :tavg, :prec, :srad, :wind, :vapr)
 
-"""
-    getraster(T::Type{WorldClim{Climate}}, [layer::Union{Tuple,Symbol}]; month, res::String="10m") => Vector{String}
-
-Download [`WorldClim`](@ref) [`Climate`](@ref) data. 
-
-# Arguments
-- `layer` `Symbol` or `Tuple` of `Symbol` from `$(layers(WorldClim{Climate}))`. 
-    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keywords
-- `month`: `Integer` or `AbstractArray` of `Integer`. Chosen from `1:12`.
-- `res`: `String` chosen from $(resolutions(WorldClim{Climate})), "10m" by default.
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 function getraster(T::Type{WorldClim{Climate}}, layers::Union{Tuple,Symbol}; 
     month, res::String=defres(T)
 )

--- a/src/worldclim/elevation.jl
+++ b/src/worldclim/elevation.jl
@@ -1,6 +1,5 @@
 layers(::Type{WorldClim{Elevation}}) = (:elev,)
 
-getraster(T::Type{WorldClim{Elevation}}; kw...) = getraster(T, :elev; kw...)
 function getraster(T::Type{WorldClim{Elevation}}, layers::Union{Tuple,Symbol}; 
     res::String=defres(T)
 )

--- a/src/worldclim/elevation.jl
+++ b/src/worldclim/elevation.jl
@@ -1,21 +1,6 @@
 layers(::Type{WorldClim{Elevation}}) = (:elev,)
 
-"""
-    getraster(T::Type{WorldClim{Elevation}}, [layer::Union{Tuple,Symbol}]; res::String="10m") => Union{Tuple,AbstractVector,String}
-
-Download [`WorldClim`](@ref) [`Elevation`](@ref) data.
-
-# Arguments
-
-- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(layers(WorldClim{Elevation}))`. 
-    Without a `layer` argument, all layers will be downloaded, and a `NamedTuple` of paths returned.
-
-# Keywords
-
-- `res`: `String` chosen from $(resolutions(WorldClim{Elevation})), "10m" by default.
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
+getraster(T::Type{WorldClim{Elevation}}; kw...) = getraster(T, :elev; kw...)
 function getraster(T::Type{WorldClim{Elevation}}, layers::Union{Tuple,Symbol}; 
     res::String=defres(T)
 )

--- a/src/worldclim/shared.jl
+++ b/src/worldclim/shared.jl
@@ -1,11 +1,3 @@
-"""
-    WorldClim{Union{BioClim,Climate,Weather}} <: RasterDataSource
-
-Data from WorldClim datasets, either [`BioClim`](@ref), [`Climate`](@ref) or 
-[`Weather`](@ref).
-
-See: [www.worldclim.org](https://www.worldclim.org)
-"""
 struct WorldClim{X} <: RasterDataSource end
 
 const WORLDCLIM_URI = URI(scheme="https", host="geodata.ucdavis.edu", path="/climate/worldclim/2_1")
@@ -19,3 +11,4 @@ rasterpath(T::Type{<:WorldClim}, layer; kw...) =
     joinpath(rasterpath(T), string(layer), rastername(T, layer; kw...))
 
 _zipfile_to_read(raster_name, zf) = first(filter(f -> f.name == raster_name, zf.files))
+

--- a/src/worldclim/weather.jl
+++ b/src/worldclim/weather.jl
@@ -1,19 +1,6 @@
 layers(::Type{WorldClim{Weather}}) = (:tmin, :tmax, :prec)
 date_step(::Type{WorldClim{Weather}}) = Month(1)
 
-"""
-    getraster(T::Type{WorldClim{Weather}}, [layer::Union{Tuple,Symbol}]; date) => Union{String,Tuple{String},Vector{String}}
-
-Download [`WorldClim`](@ref) [`Weather`](@ref) data, for `layer`/s in: `$(layers(WorldClim{Weather}))`.
-Without a layer argument, all layers will be downloaded, and a `NamedTuple` of paths returned. 
-
-# Keywords
-
-- `date`: a `Date` or `DateTime` object, a `Vector` of dates, or `Tuple` of start/end dates.
-    WorldClim Weather is available with a daily timestep. 
-
-Returns the filepath/s of the downloaded or pre-existing files.
-"""
 function getraster(T::Type{WorldClim{Weather}}, layers::Union{Tuple,Symbol}; date)
     _getraster(T, layers, date)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ end
 @time @safetestset "worldclim elevation" begin include("worldclim-elevation.jl") end
 # SRTM SSL certs have expired
 # @time @safetestset "srtm" begin include("srtm.jl") end
-@time @safetestset "modis utilities" begin include("modis-utilities.jl") end
+# MODIS utilities are broken because the EPSG coordinate transform API is retired
+# @time @safetestset "modis utilities" begin include("modis-utilities.jl") end
 @time @safetestset "modis product info" begin include("modis-products.jl") end
-@time @safetestset "modis interface" begin include("modis-interface.jl") end
+# @time @safetestset "modis interface" begin include("modis-interface.jl") end


### PR DESCRIPTION
Following up on my own idea here from
https://github.com/EcoJulia/RasterDataSources.jl/issues/75

The idea is to have one main `getraster` docstring (which I even shortened a little), and otherwise specify arguments under each source

closes #75 