### PR TITLE
Add automatic Scratch.jl fallback for storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,32 @@ Install as usual with:
 ] add RasterDataSources
 ```
 
-To download data you will need to specify a folder to put it in. You can do this
-by assigning the environment variable `RASTERDATASOURCES_PATH`:
+### Storage Configuration
+
+RasterDataSources.jl automatically handles data storage for you. By default, it will create a persistent scratch directory to store downloaded raster data. No manual configuration is required to get started.
+
+#### Automatic Storage (Recommended)
+
+When you first use RasterDataSources.jl, it will automatically create a scratch directory using Julia's Scratch.jl package. This directory persists across Julia sessions and package updates, so your downloaded data won't be lost.
+
+```julia
+julia> using RasterDataSources
+julia> getraster(WorldClim{Climate}, :wind; month=1)  # Automatically uses scratch storage
+```
+
+#### Custom Storage Location (Optional)
+
+If you prefer to specify your own storage location, you can set the `RASTERDATASOURCES_PATH` environment variable:
 
 ```julia
 ENV["RASTERDATASOURCES_PATH"] = "/home/user/Data/"
 ```
 
-This can be put in your `startup.jl` file or the system environment.
+This can be put in your `startup.jl` file or the system environment. When this variable is set, RasterDataSources.jl will use your specified directory instead of the automatic scratch directory.
+
+#### Finding Your Storage Location
+
+The storage location is managed internally by RasterDataSources.jl. When using automatic storage, the exact path is handled by Julia's Scratch.jl package and will be in your system's scratch directory.
 
 
 RasterDataSources was based on code from the `SimpleSDMDataSoures.jl` package by Timothée Poisot.

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -10,7 +10,8 @@ using Dates,
       URIs,
       ZipFile,
       ASCIIrasters,
-      DelimitedFiles
+      DelimitedFiles,
+      Scratch
 
 import JSON.Parser as JP
 

--- a/src/alwb/alwb.jl
+++ b/src/alwb/alwb.jl
@@ -67,7 +67,7 @@ This will return the file containing annual averages, including your date:
 
 ```julia
 julia> getraster(ALWB{Values,Year}, :ss_pct; date=Date(2001, 2))
-"/your/RASTERDATASOURCES_PATH/ALWB/values/month/ss_pct.nc"
+"/path/to/storage/ALWB/values/month/ss_pct.nc"
 ```
 
 Returns the filepath/s of the downloaded or pre-existing files.

--- a/src/modis/products.jl
+++ b/src/modis/products.jl
@@ -17,7 +17,7 @@ end
 """
     Lists available layers for a given MODIS Product
 
-Looks in `joinpath(ENV["RASTERDATASOURCES_PATH"]/MODIS/layers` for
+Looks in the storage directory under `MODIS/layers` for
 a file with the right name. If not found, sends a request to the server
 to get the list.
 

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -73,11 +73,42 @@ function _maybe_download(uri::URI, filepath, headers = [])
     filepath
 end
 
+"""
+    rasterpath()
+
+Returns the absolute path to the directory where raster data is stored.
+
+The storage location is determined using the following priority order:
+1. If the `RASTERDATASOURCES_PATH` environment variable is set and points to a valid directory, that path is used
+2. If no environment variable is set, a persistent scratch directory is automatically created using Scratch.jl
+
+The scratch directory persists across Julia sessions and package updates, ensuring downloaded data is not lost.
+If scratch directory creation fails, an error is thrown with instructions to manually set the environment variable.
+
+# Examples
+```julia
+# With environment variable set
+ENV["RASTERDATASOURCES_PATH"] = "/path/to/data"
+rasterpath()  # Returns "/path/to/data"
+
+# Without environment variable (automatic scratch directory)
+rasterpath()  # Returns something like "/Users/username/.julia/scratchspaces/12345.../raster_data"
+```
+"""
 function rasterpath()
+    # Priority 1: Use environment variable if set and valid
     if haskey(ENV, "RASTERDATASOURCES_PATH") && isdir(ENV["RASTERDATASOURCES_PATH"])
-        ENV["RASTERDATASOURCES_PATH"]
-    else
-        error("You must set `ENV[\"RASTERDATASOURCES_PATH\"]` to a path in your system")
+        return ENV["RASTERDATASOURCES_PATH"]
+    end
+    
+    # Priority 2: Use scratch directory
+    try
+        scratch_dir = @get_scratch!("raster_data")
+        @debug "Using scratch directory for raster data storage: $scratch_dir"
+        return scratch_dir
+    catch e
+        error("Failed to create scratch directory for raster data storage. " *
+              "Please set ENV[\"RASTERDATASOURCES_PATH\"] manually. Error: $e")
     end
 end
 

--- a/test/awap.jl
+++ b/test/awap.jl
@@ -4,14 +4,14 @@ using RasterDataSources: rastername, rasterpath, zipurl, zipname, zippath
 @testset "AWAP" begin
     using RasterDataSources: rastername, zipurl, zipname, zippath
 
-    raster_file = joinpath(ENV["RASTERDATASOURCES_PATH"], "AWAP", "vprp", "vprph09", "20010101.grid")
+    raster_file = joinpath(rasterpath(), "AWAP", "vprp", "vprph09", "20010101.grid")
     @test rasterpath(AWAP, :vprpress09; date=Date(2001, 1)) == raster_file
     @test rastername(AWAP, :vprpress09; date=Date(2001, 1)) == "20010101.grid" 
 
     @test zipurl(AWAP, :vprpress09; date=Date(2001, 1)) ==
         URI(scheme="http", host="www.bom.gov.au", path="/web03/ncc/www/awap/vprp/vprph09/daily/grid/0.05/history/nat/2001010120010101.grid.Z")
     @test zippath(AWAP, :vprpress09; date=Date(2001, 1)) ==
-        joinpath(ENV["RASTERDATASOURCES_PATH"], "AWAP", "vprp", "vprph09", "20010101.grid.Z")
+        joinpath(rasterpath(), "AWAP", "vprp", "vprph09", "20010101.grid.Z")
     @test zipname(AWAP, :vprpress09; date=Date(2001, 1)) == "20010101.grid.Z"
 
     if Sys.islinux()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,3 +30,4 @@ end
 # @time @safetestset "modis utilities" begin include("modis-utilities.jl") end
 @time @safetestset "modis product info" begin include("modis-products.jl") end
 # @time @safetestset "modis interface" begin include("modis-interface.jl") end
+@time @safetestset "storage path resolution" begin include("storage-path.jl") end

--- a/test/storage-path.jl
+++ b/test/storage-path.jl
@@ -1,0 +1,206 @@
+using Test, RasterDataSources, Scratch
+using RasterDataSources: rasterpath
+import Scratch: @get_scratch!
+
+@testset "Storage Path Resolution" begin
+    
+    @testset "rasterpath() with RASTERDATASOURCES_PATH set to valid directory" begin
+        # Create a temporary directory for testing
+        temp_dir = mktempdir()
+        
+        try
+            # Set environment variable to valid directory
+            ENV["RASTERDATASOURCES_PATH"] = temp_dir
+            
+            # Test that rasterpath() returns the environment variable path
+            @test rasterpath() == temp_dir
+            @test isdir(rasterpath())
+            
+        finally
+            # Clean up
+            delete!(ENV, "RASTERDATASOURCES_PATH")
+            rm(temp_dir, recursive=true, force=true)
+        end
+    end
+    
+    @testset "rasterpath() with RASTERDATASOURCES_PATH unset (scratch directory creation)" begin
+        # Ensure environment variable is not set
+        if haskey(ENV, "RASTERDATASOURCES_PATH")
+            old_path = ENV["RASTERDATASOURCES_PATH"]
+            delete!(ENV, "RASTERDATASOURCES_PATH")
+        else
+            old_path = nothing
+        end
+        
+        try
+            # Test that rasterpath() creates and returns scratch directory
+            scratch_path = rasterpath()
+            
+            @test isa(scratch_path, String)
+            @test isdir(scratch_path)
+            @test isabspath(scratch_path)
+            
+            # Verify it's actually a scratch directory by checking it contains expected patterns
+            # Scratch directories typically contain package UUID or similar identifiers
+            @test occursin("raster_data", scratch_path) || occursin("RasterDataSources", scratch_path)
+            
+            # Test that subsequent calls return the same path
+            @test rasterpath() == scratch_path
+            
+        finally
+            # Restore environment variable if it existed
+            if old_path !== nothing
+                ENV["RASTERDATASOURCES_PATH"] = old_path
+            end
+        end
+    end
+    
+    @testset "rasterpath() with RASTERDATASOURCES_PATH set to invalid directory" begin
+        # Set environment variable to non-existent directory
+        invalid_path = "/this/path/does/not/exist/$(rand(UInt32))"
+        ENV["RASTERDATASOURCES_PATH"] = invalid_path
+        
+        try
+            # Should fall back to scratch directory when env var points to invalid path
+            scratch_path = rasterpath()
+            
+            @test isa(scratch_path, String)
+            @test isdir(scratch_path)
+            @test scratch_path != invalid_path
+            @test isabspath(scratch_path)
+            
+        finally
+            delete!(ENV, "RASTERDATASOURCES_PATH")
+        end
+    end
+    
+    @testset "get_raster_storage_path() function consistency" begin
+        # This test assumes get_raster_storage_path() will be implemented
+        # Skip if function doesn't exist yet
+        if isdefined(RasterDataSources, :get_raster_storage_path)
+            # Test with environment variable set
+            temp_dir = mktempdir()
+            try
+                ENV["RASTERDATASOURCES_PATH"] = temp_dir
+                
+                @test RasterDataSources.get_raster_storage_path() == rasterpath()
+                @test RasterDataSources.get_raster_storage_path() == temp_dir
+                
+            finally
+                delete!(ENV, "RASTERDATASOURCES_PATH")
+                rm(temp_dir, recursive=true, force=true)
+            end
+            
+            # Test with scratch directory
+            if haskey(ENV, "RASTERDATASOURCES_PATH")
+                old_path = ENV["RASTERDATASOURCES_PATH"]
+                delete!(ENV, "RASTERDATASOURCES_PATH")
+            else
+                old_path = nothing
+            end
+            
+            try
+                @test RasterDataSources.get_raster_storage_path() == rasterpath()
+                @test isdir(RasterDataSources.get_raster_storage_path())
+                
+            finally
+                if old_path !== nothing
+                    ENV["RASTERDATASOURCES_PATH"] = old_path
+                end
+            end
+        else
+            @test_skip "get_raster_storage_path() function not yet implemented"
+        end
+    end
+    
+    @testset "Mock Scratch.jl functions to test failure scenarios" begin
+        # Save original environment state
+        original_env = get(ENV, "RASTERDATASOURCES_PATH", nothing)
+        if haskey(ENV, "RASTERDATASOURCES_PATH")
+            delete!(ENV, "RASTERDATASOURCES_PATH")
+        end
+        
+        try
+            # Test scratch directory creation failure by mocking @get_scratch!
+            # This is tricky to test directly since @get_scratch! is a macro
+            # Instead, we'll test the error handling path by temporarily making
+            # the scratch directory inaccessible
+            
+            # First, get a valid scratch directory
+            scratch_path = rasterpath()
+            @test isdir(scratch_path)
+            
+            # The error scenario is difficult to mock without modifying the source
+            # So we'll test that the function handles the success case properly
+            # and document that failure testing would require dependency injection
+            # Note: rasterpath() may print info messages, so we just test it doesn't error
+            result = rasterpath()
+            @test isa(result, String)
+            
+        finally
+            # Restore original environment
+            if original_env !== nothing
+                ENV["RASTERDATASOURCES_PATH"] = original_env
+            end
+        end
+    end
+    
+    @testset "Storage path switching behavior" begin
+        # Test switching between environment variable and scratch directory
+        temp_dir = mktempdir()
+        
+        try
+            # Start with scratch directory
+            if haskey(ENV, "RASTERDATASOURCES_PATH")
+                old_path = ENV["RASTERDATASOURCES_PATH"]
+                delete!(ENV, "RASTERDATASOURCES_PATH")
+            else
+                old_path = nothing
+            end
+            
+            scratch_path = rasterpath()
+            @test isdir(scratch_path)
+            
+            # Switch to environment variable
+            ENV["RASTERDATASOURCES_PATH"] = temp_dir
+            env_path = rasterpath()
+            @test env_path == temp_dir
+            @test env_path != scratch_path
+            
+            # Switch back to scratch directory
+            delete!(ENV, "RASTERDATASOURCES_PATH")
+            back_to_scratch = rasterpath()
+            @test back_to_scratch == scratch_path
+            @test isdir(back_to_scratch)
+            
+            # Restore original state
+            if old_path !== nothing
+                ENV["RASTERDATASOURCES_PATH"] = old_path
+            end
+            
+        finally
+            rm(temp_dir, recursive=true, force=true)
+        end
+    end
+    
+    @testset "Path properties and validation" begin
+        # Test various properties of returned paths
+        path = rasterpath()
+        
+        @test isa(path, String)
+        @test !isempty(path)
+        @test isdir(path)
+        @test isabspath(path)
+        
+        # Test that the path is writable
+        test_file = joinpath(path, "test_write_$(rand(UInt32)).txt")
+        try
+            write(test_file, "test")
+            @test isfile(test_file)
+            @test read(test_file, String) == "test"
+        finally
+            rm(test_file, force=true)
+        end
+    end
+    
+end


### PR DESCRIPTION
Add Scratch.jl fallback if RASTERDATASOURCES_PATH is not present, this removes the most common user footgun.

AI generated.