### PR TITLE
Upgrade to JSON.jl v1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ RasterDataSourcesProjExt = "Proj"
 [compat]
 ASCIIrasters = "0.1"
 HTTP = "0.8, 0.9, 1"
-JSON = "0.21, 1"
+JSON = "1"
 Proj = "1"
 URIs = "1"
 ZipFile = "0.9, 0.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RasterDataSources"
 uuid = "3cb90ccd-e1b6-4867-9617-4276c8b2ca36"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>", "Timothée Poisot <timothee.poisot@umontreal.ca>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 ASCIIrasters = "81770e7c-c736-4fa5-8129-46dd21831640"
@@ -21,7 +21,7 @@ RasterDataSourcesProjExt = "Proj"
 [compat]
 ASCIIrasters = "0.1"
 HTTP = "0.8, 0.9, 1"
-JSON = "0.21"
+JSON = "0.21, 1"
 Proj = "1"
 URIs = "1"
 ZipFile = "0.9, 0.10"

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -12,7 +12,7 @@ using Dates,
       ASCIIrasters,
       DelimitedFiles
 
-import JSON.Parser as JP
+import JSON
 
 export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM, MODIS
 

--- a/src/modis/products.jl
+++ b/src/modis/products.jl
@@ -85,7 +85,7 @@ function list_dates(
         )
 
         # parse
-        body = JP.parse(String(r.body))
+        body = JSON.parse(String(r.body))
         
         # prebuild columns
         calendardates = String[]

--- a/src/modis/utilities.jl
+++ b/src/modis/utilities.jl
@@ -59,7 +59,7 @@ function modis_request(T::Type{<:ModisProduct}, layer, lat, lon, km_ab, km_lr, f
 
     r = HTTP.request("GET", URI(base_uri * query), ["Accept" => "application/json"])
 
-    body = JP.parse(String(r.body))
+    body = JSON.parse(String(r.body))
 
     # The server outputs data in a nested JSON array that we can
     # parse manually : the highest level is a metadata array with


### PR DESCRIPTION
This is actually not breaking I think, since we only ever used `JSON.parse`.

But it's necessary to allow GeoJSON.jl to coexist in an env with RDS and have it be using the new JSON.jl v1.

I tried to run CI locally but of course worldclim failed....seriously I feel like we should just test the server works first and if that fails, skip it :D 

cc @rafaqz

