### PR TITLE
add CPCsoil data

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently sources include:
 | TerraClimate | https://www.climatologylab.org/terraclimate.html | Historical, Plus2C, Plus4C       |
 | NCEP         | https://psl.noaa.gov/data/gridded/data.ncep.reanalysis.html | Complete              |
 | SLGA         | https://esoil.io/TERNLandscapes/Public/Pages/SLGA/index.html | Soil attributes and CoarseFragments |
+| CPCSoil      | https://psl.noaa.gov/data/gridded/data.cpcsoil.html | LTM climatology and historical monthly means |
 
 Please open an issue if you need more datasets added, or (even better) open a pull request 
 following the form of the other datasets where possible.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -95,6 +95,13 @@ SRTM
 SLGA
 ```
 
+## CPCSoil
+
+```@docs
+CPCSoilMean
+CPCSoil
+```
+
 # Datasets
 
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -98,7 +98,7 @@ SLGA
 ## CPCSoil
 
 ```@docs
-CPCSoilMean
+Mean
 CPCSoil
 ```
 

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -15,7 +15,7 @@ using Dates,
 
 import JSON
 
-export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM, CopernicusDEM, MODIS, ERA5, NCEP, TerraClimate, GRIDMET, SLGA, CoarseFragments
+export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM, CopernicusDEM, MODIS, ERA5, NCEP, TerraClimate, GRIDMET, SLGA, CoarseFragments, CPCSoil, CPCSoilMean
 
 export BioClim, BioClimPlus, Climate, Weather, Elevation, LandCover, HabitatHeterogeneity
 
@@ -88,6 +88,8 @@ include("gridmet/gridmet.jl")
 
 include("slga/slga.jl")
 include("slga/coarsefragments.jl")
+
+include("cpcsoil/cpcsoil.jl")
 
 include("interface.jl")
 

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -15,7 +15,7 @@ using Dates,
 
 import JSON
 
-export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM, CopernicusDEM, MODIS, ERA5, NCEP, TerraClimate, GRIDMET, SLGA, CoarseFragments, CPCSoil, CPCSoilMean
+export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM, CopernicusDEM, MODIS, ERA5, NCEP, TerraClimate, GRIDMET, SLGA, CoarseFragments, CPCSoil, Mean
 
 export BioClim, BioClimPlus, Climate, Weather, Elevation, LandCover, HabitatHeterogeneity
 

--- a/src/cpcsoil/cpcsoil.jl
+++ b/src/cpcsoil/cpcsoil.jl
@@ -1,0 +1,96 @@
+const CPCSOIL_URI = URI(scheme="https", host="psl.noaa.gov",
+    path="/thredds/fileServer/Datasets/cpcsoil")
+
+const CPCSOIL_LTM_PERIODS = ("1991-2020", "1981-2010")
+
+"""
+    CPCSoilMean
+
+Type parameter for [`CPCSoil`](@ref) selecting the full historical monthly
+mean time series (`soilw.mon.mean.v2.nc`, 254 MB) rather than a long-term
+mean climatology.
+
+```julia
+getraster(CPCSoil{CPCSoilMean})
+```
+"""
+struct CPCSoilMean end
+
+"""
+    CPCSoil{X} <: RasterDataSource
+
+Monthly soil moisture data from the NOAA Climate Prediction Center (CPC),
+on a global 0.5° grid.
+
+Two products are available:
+
+**Long-term mean (LTM)** — `CPCSoil` (default):
+12 monthly climatological means for a selected 30-year period.
+Use the `period` keyword to select the climatology:
+- `"1991-2020"` (default, 9.5 MB)
+- `"1981-2010"` (3.2 MB)
+
+**Historical monthly means** — `CPCSoil{CPCSoilMean}`:
+Full monthly time series from 1948 to present (254 MB).
+
+See: [psl.noaa.gov/data/gridded/data.cpcsoil.html](https://psl.noaa.gov/data/gridded/data.cpcsoil.html)
+
+Reference: Fan, Y. and van den Dool, H. (2004). Climate Prediction Center global
+monthly soil moisture data set at 0.5° resolution for 1948 to present.
+*Journal of Geophysical Research*, 109, D10102.
+
+# Usage with `getraster`
+    getraster(source::Type{CPCSoil}; period="1991-2020")
+    getraster(source::Type{CPCSoil{CPCSoilMean}})
+
+# Examples
+```julia
+julia> getraster(CPCSoil)
+"/path/to/storage/CPCSoil/soilw.mon.1991-2020.ltm.v2.nc"
+
+julia> getraster(CPCSoil; period="1981-2010")
+"/path/to/storage/CPCSoil/soilw.mon.1981-2010.ltm.v2.nc"
+
+julia> getraster(CPCSoil{CPCSoilMean})
+"/path/to/storage/CPCSoil/soilw.mon.mean.v2.nc"
+```
+
+Returns the filepath of the downloaded or pre-existing file.
+"""
+struct CPCSoil{X} <: RasterDataSource end
+
+defperiod(::Type{CPCSoil}) = "1991-2020"
+
+function _check_period(::Type{CPCSoil}, period)
+    period in CPCSOIL_LTM_PERIODS || throw(ArgumentError(
+        "Period \"$period\" is not available. Choose from: $(join(CPCSOIL_LTM_PERIODS, ", "))"
+    ))
+end
+
+getraster_keywords(::Type{CPCSoil}) = (:period,)
+
+rastername(::Type{CPCSoil}; period) = "soilw.mon.$(period).ltm.v2.nc"
+
+rasterpath(::Type{CPCSoil}) = joinpath(rasterpath(), "CPCSoil")
+rasterpath(T::Type{CPCSoil}; period) = joinpath(rasterpath(T), rastername(T; period))
+
+rasterurl(T::Type{CPCSoil}; period) = joinpath(CPCSOIL_URI, rastername(T; period))
+
+function getraster(T::Type{CPCSoil}; period=defperiod(T))
+    _check_period(T, period)
+    _maybe_download(rasterurl(T; period), rasterpath(T; period))
+end
+
+getraster_keywords(::Type{CPCSoil{CPCSoilMean}}) = ()
+
+rastername(::Type{CPCSoil{CPCSoilMean}}) = "soilw.mon.mean.v2.nc"
+
+rasterpath(T::Type{CPCSoil{CPCSoilMean}}) =
+    joinpath(rasterpath(), "CPCSoil", rastername(T))
+
+rasterurl(T::Type{CPCSoil{CPCSoilMean}}) =
+    joinpath(CPCSOIL_URI, rastername(T))
+
+function getraster(T::Type{CPCSoil{CPCSoilMean}})
+    _maybe_download(rasterurl(T), rasterpath(T))
+end

--- a/src/cpcsoil/cpcsoil.jl
+++ b/src/cpcsoil/cpcsoil.jl
@@ -69,12 +69,13 @@ end
 
 getraster_keywords(::Type{CPCSoil}) = (:period,)
 
-rastername(::Type{CPCSoil}; period) = "soilw.mon.$(period).ltm.v2.nc"
+rastername(::Type{CPCSoil}; period=defperiod(CPCSoil)) = "soilw.mon.$(period).ltm.v2.nc"
 
-rasterpath(::Type{CPCSoil}) = joinpath(rasterpath(), "CPCSoil")
-rasterpath(T::Type{CPCSoil}; period) = joinpath(rasterpath(T), rastername(T; period))
+rasterpath(T::Type{CPCSoil}; period=defperiod(T)) =
+    joinpath(rasterpath(), "CPCSoil", rastername(T; period))
 
-rasterurl(T::Type{CPCSoil}; period) = joinpath(CPCSOIL_URI, rastername(T; period))
+rasterurl(T::Type{CPCSoil}; period=defperiod(T)) =
+    joinpath(CPCSOIL_URI, rastername(T; period))
 
 function getraster(T::Type{CPCSoil}; period=defperiod(T))
     _check_period(T, period)

--- a/src/cpcsoil/cpcsoil.jl
+++ b/src/cpcsoil/cpcsoil.jl
@@ -4,19 +4,6 @@ const CPCSOIL_URI = URI(scheme="https", host="psl.noaa.gov",
 const CPCSOIL_LTM_PERIODS = ("1991-2020", "1981-2010")
 
 """
-    CPCSoilMean
-
-Type parameter for [`CPCSoil`](@ref) selecting the full historical monthly
-mean time series (`soilw.mon.mean.v2.nc`, 254 MB) rather than a long-term
-mean climatology.
-
-```julia
-getraster(CPCSoil{CPCSoilMean})
-```
-"""
-struct CPCSoilMean end
-
-"""
     CPCSoil{X} <: RasterDataSource
 
 Monthly soil moisture data from the NOAA Climate Prediction Center (CPC),
@@ -30,7 +17,7 @@ Use the `period` keyword to select the climatology:
 - `"1991-2020"` (default, 9.5 MB)
 - `"1981-2010"` (3.2 MB)
 
-**Historical monthly means** — `CPCSoil{CPCSoilMean}`:
+**Historical monthly means** — `CPCSoil{Mean}`:
 Full monthly time series from 1948 to present (254 MB).
 
 See: [psl.noaa.gov/data/gridded/data.cpcsoil.html](https://psl.noaa.gov/data/gridded/data.cpcsoil.html)
@@ -41,7 +28,7 @@ monthly soil moisture data set at 0.5° resolution for 1948 to present.
 
 # Usage with `getraster`
     getraster(source::Type{CPCSoil}; period="1991-2020")
-    getraster(source::Type{CPCSoil{CPCSoilMean}})
+    getraster(source::Type{CPCSoil{Mean}})
 
 # Examples
 ```julia
@@ -51,7 +38,7 @@ julia> getraster(CPCSoil)
 julia> getraster(CPCSoil; period="1981-2010")
 "/path/to/storage/CPCSoil/soilw.mon.1981-2010.ltm.v2.nc"
 
-julia> getraster(CPCSoil{CPCSoilMean})
+julia> getraster(CPCSoil{Mean})
 "/path/to/storage/CPCSoil/soilw.mon.mean.v2.nc"
 ```
 
@@ -82,16 +69,16 @@ function getraster(T::Type{CPCSoil}; period=defperiod(T))
     _maybe_download(rasterurl(T; period), rasterpath(T; period))
 end
 
-getraster_keywords(::Type{CPCSoil{CPCSoilMean}}) = ()
+getraster_keywords(::Type{CPCSoil{Mean}}) = ()
 
-rastername(::Type{CPCSoil{CPCSoilMean}}) = "soilw.mon.mean.v2.nc"
+rastername(::Type{CPCSoil{Mean}}) = "soilw.mon.mean.v2.nc"
 
-rasterpath(T::Type{CPCSoil{CPCSoilMean}}) =
+rasterpath(T::Type{CPCSoil{Mean}}) =
     joinpath(rasterpath(), "CPCSoil", rastername(T))
 
-rasterurl(T::Type{CPCSoil{CPCSoilMean}}) =
+rasterurl(T::Type{CPCSoil{Mean}}) =
     joinpath(CPCSOIL_URI, rastername(T))
 
-function getraster(T::Type{CPCSoil{CPCSoilMean}})
+function getraster(T::Type{CPCSoil{Mean}})
     _maybe_download(rasterurl(T), rasterpath(T))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -275,6 +275,18 @@ See the [`EarthEnv`](@ref) docs for implementation details.
 struct HabitatHeterogeneity <: RasterDataSet end
 
 """
+    Mean
+
+Type parameter for data sources that provide a long-term mean (or historical mean)
+product in addition to a climatological one. Currently used with [`CPCSoil`](@ref):
+
+```julia
+getraster(CPCSoil{Mean})  # full monthly time series 1948–present
+```
+"""
+struct Mean end
+
+"""
     ModisProduct <: RasterDataSet
 
 Abstract supertype for [`MODIS`](@ref)/VIIRS products. 

--- a/test/cpcsoil.jl
+++ b/test/cpcsoil.jl
@@ -4,13 +4,11 @@ using RasterDataSources: rastername, rasterurl, rasterpath
 @testset "CPCSoil" begin
     cpcsoil_dir = joinpath(ENV["RASTERDATASOURCES_PATH"], "CPCSoil")
 
-    @test rasterpath(CPCSoil) == cpcsoil_dir
-
-    @testset "LTM period 1991-2020" begin
+    @testset "LTM period 1991-2020 (default)" begin
         path = joinpath(cpcsoil_dir, "soilw.mon.1991-2020.ltm.v2.nc")
-        @test rasterpath(CPCSoil; period="1991-2020") == path
-        @test rastername(CPCSoil; period="1991-2020") == "soilw.mon.1991-2020.ltm.v2.nc"
-        @test rasterurl(CPCSoil; period="1991-2020") == URI(scheme="https", host="psl.noaa.gov",
+        @test rasterpath(CPCSoil) == path
+        @test rastername(CPCSoil) == "soilw.mon.1991-2020.ltm.v2.nc"
+        @test rasterurl(CPCSoil) == URI(scheme="https", host="psl.noaa.gov",
             path="/thredds/fileServer/Datasets/cpcsoil/soilw.mon.1991-2020.ltm.v2.nc")
         @test RasterDataSources.getraster_keywords(CPCSoil) == (:period,)
     end
@@ -40,12 +38,6 @@ using RasterDataSources: rastername, rasterurl, rasterpath
         @testset "download LTM" begin
             path = joinpath(cpcsoil_dir, "soilw.mon.1991-2020.ltm.v2.nc")
             @test getraster(CPCSoil) == path
-            @test isfile(path)
-        end
-
-        @testset "download historical" begin
-            path = joinpath(cpcsoil_dir, "soilw.mon.mean.v2.nc")
-            @test getraster(CPCSoil{CPCSoilMean}) == path
             @test isfile(path)
         end
     end

--- a/test/cpcsoil.jl
+++ b/test/cpcsoil.jl
@@ -25,13 +25,13 @@ using RasterDataSources: rastername, rasterurl, rasterpath
         @test_throws ArgumentError getraster(CPCSoil; period="2000-2030")
     end
 
-    @testset "CPCSoilMean" begin
+    @testset "Mean" begin
         path = joinpath(cpcsoil_dir, "soilw.mon.mean.v2.nc")
-        @test rasterpath(CPCSoil{CPCSoilMean}) == path
-        @test rastername(CPCSoil{CPCSoilMean}) == "soilw.mon.mean.v2.nc"
-        @test rasterurl(CPCSoil{CPCSoilMean}) == URI(scheme="https", host="psl.noaa.gov",
+        @test rasterpath(CPCSoil{Mean}) == path
+        @test rastername(CPCSoil{Mean}) == "soilw.mon.mean.v2.nc"
+        @test rasterurl(CPCSoil{Mean}) == URI(scheme="https", host="psl.noaa.gov",
             path="/thredds/fileServer/Datasets/cpcsoil/soilw.mon.mean.v2.nc")
-        @test RasterDataSources.getraster_keywords(CPCSoil{CPCSoilMean}) == ()
+        @test RasterDataSources.getraster_keywords(CPCSoil{Mean}) == ()
     end
 
     if !Sys.iswindows()

--- a/test/cpcsoil.jl
+++ b/test/cpcsoil.jl
@@ -1,0 +1,52 @@
+using RasterDataSources, URIs, Test
+using RasterDataSources: rastername, rasterurl, rasterpath
+
+@testset "CPCSoil" begin
+    cpcsoil_dir = joinpath(ENV["RASTERDATASOURCES_PATH"], "CPCSoil")
+
+    @test rasterpath(CPCSoil) == cpcsoil_dir
+
+    @testset "LTM period 1991-2020" begin
+        path = joinpath(cpcsoil_dir, "soilw.mon.1991-2020.ltm.v2.nc")
+        @test rasterpath(CPCSoil; period="1991-2020") == path
+        @test rastername(CPCSoil; period="1991-2020") == "soilw.mon.1991-2020.ltm.v2.nc"
+        @test rasterurl(CPCSoil; period="1991-2020") == URI(scheme="https", host="psl.noaa.gov",
+            path="/thredds/fileServer/Datasets/cpcsoil/soilw.mon.1991-2020.ltm.v2.nc")
+        @test RasterDataSources.getraster_keywords(CPCSoil) == (:period,)
+    end
+
+    @testset "LTM period 1981-2010" begin
+        path = joinpath(cpcsoil_dir, "soilw.mon.1981-2010.ltm.v2.nc")
+        @test rasterpath(CPCSoil; period="1981-2010") == path
+        @test rastername(CPCSoil; period="1981-2010") == "soilw.mon.1981-2010.ltm.v2.nc"
+        @test rasterurl(CPCSoil; period="1981-2010") == URI(scheme="https", host="psl.noaa.gov",
+            path="/thredds/fileServer/Datasets/cpcsoil/soilw.mon.1981-2010.ltm.v2.nc")
+    end
+
+    @testset "invalid period" begin
+        @test_throws ArgumentError getraster(CPCSoil; period="2000-2030")
+    end
+
+    @testset "CPCSoilMean" begin
+        path = joinpath(cpcsoil_dir, "soilw.mon.mean.v2.nc")
+        @test rasterpath(CPCSoil{CPCSoilMean}) == path
+        @test rastername(CPCSoil{CPCSoilMean}) == "soilw.mon.mean.v2.nc"
+        @test rasterurl(CPCSoil{CPCSoilMean}) == URI(scheme="https", host="psl.noaa.gov",
+            path="/thredds/fileServer/Datasets/cpcsoil/soilw.mon.mean.v2.nc")
+        @test RasterDataSources.getraster_keywords(CPCSoil{CPCSoilMean}) == ()
+    end
+
+    if !Sys.iswindows()
+        @testset "download LTM" begin
+            path = joinpath(cpcsoil_dir, "soilw.mon.1991-2020.ltm.v2.nc")
+            @test getraster(CPCSoil) == path
+            @test isfile(path)
+        end
+
+        @testset "download historical" begin
+            path = joinpath(cpcsoil_dir, "soilw.mon.mean.v2.nc")
+            @test getraster(CPCSoil{CPCSoilMean}) == path
+            @test isfile(path)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,4 +36,5 @@ using SafeTestsets, Aqua, RasterDataSources, Pkg, Dates
 @time @safetestset "modis extent" begin include("modis-extent.jl") end
 @time @safetestset "ncep" begin include("ncep.jl") end
 @time @safetestset "slga" begin include("slga.jl") end
+@time @safetestset "cpcsoil" begin include("cpcsoil.jl") end
 # @time @safetestset "modis interface" begin include("modis-interface.jl") end


### PR DESCRIPTION
Adds NOAA CPC global soil moisture (0.5° grid) with two products:

CPCSoil — 30-year LTM climatology (period keyword selects 1991–2020 or 1981–2010)
CPCSoil{CPCSoilMean} — full monthly time series 1948–present (254 MB)
Data served from the NOAA PSL THREDDS server.