### PR TITLE
Add static elevation layer to GRIDMET

### DIFF
--- a/src/gridmet/gridmet.jl
+++ b/src/gridmet/gridmet.jl
@@ -1,4 +1,5 @@
 const GRIDMET_URI = URI(scheme="https", host="www.northwestknowledge.net", path="/metdata/data")
+const GRIDMET_ELEV_URI = URI("http://thredds.northwestknowledge.net:8080/thredds/fileServer/MET/elev/metdata_elevationdata.nc")
 
 const GRIDMET_LAYERS = (
     tmmx = (description="Maximum near-surface air temperature",                    units="K"),
@@ -22,6 +23,7 @@ const GRIDMET_LAYERS = (
     spi  = (description="Standardized Precipitation Index",                       units="unitless"),
     spei = (description="Standardized Precipitation-Evapotranspiration Index",    units="unitless"),
     eddi = (description="Evaporative Demand Drought Index",                        units="unitless"),
+    elev = (description="Elevation",                                              units="m"),
 )
 
 @doc """
@@ -37,7 +39,8 @@ contains daily layers for the full calendar year. Coverage is from 1979 to prese
 
 The available layers are: `$(keys(GRIDMET_LAYERS))`.
 
-`getraster` for `GRIDMET` requires a `date` keyword to specify the year to download.
+`getraster` for `GRIDMET` requires a `date` keyword to specify the year to download,
+except for the static `elev` layer, which is a single unchanging file and ignores `date`.
 
 # Usage with `getraster`
     getraster(source::Type{GRIDMET}, [layer]; date)
@@ -49,6 +52,7 @@ The available layers are: `$(keys(GRIDMET_LAYERS))`.
 # Keywords
 - `date`: a `Date`, `AbstractVector` of `Date`, or a `Tuple` of start and end dates.
     Only the year component is used. For multiple dates, a `Vector` of paths is returned.
+    Not required when `layer` is `:elev`.
 
 # Example
 ```julia
@@ -60,6 +64,9 @@ julia> getraster(GRIDMET, (:tmmx, :pr); date=Date(2020))
 
 julia> getraster(GRIDMET, :tmmx; date=(Date(2018), Date(2020)))
 [".../tmmx_2018.nc", ".../tmmx_2019.nc", ".../tmmx_2020.nc"]
+
+julia> getraster(GRIDMET, :elev)
+"/path/to/storage/GRIDMET/elev/metdata_elevationdata.nc"
 ```
 
 Returns the filepath/s of the downloaded or pre-existing files.
@@ -71,16 +78,17 @@ date_step(::Type{GRIDMET}) = Year(1)
 date_range(::Type{GRIDMET}) = (Date(1979, 1, 1), Date(2025, 12, 31))
 getraster_keywords(::Type{GRIDMET}) = (:date,)
 
-rastername(::Type{GRIDMET}, layer::Symbol; date) = "$(layer)_$(year(date)).nc"
+rastername(::Type{GRIDMET}, layer::Symbol; date=nothing) =
+    layer === :elev ? "metdata_elevationdata.nc" : "$(layer)_$(year(date)).nc"
 
 rasterpath(::Type{GRIDMET}) = joinpath(rasterpath(), "GRIDMET")
-rasterpath(T::Type{GRIDMET}, layer::Symbol; date) =
+rasterpath(T::Type{GRIDMET}, layer::Symbol; date=nothing) =
     joinpath(rasterpath(T), string(layer), rastername(T, layer; date))
 
-rasterurl(T::Type{GRIDMET}, layer::Symbol; date) =
-    joinpath(GRIDMET_URI, rastername(T, layer; date))
+rasterurl(T::Type{GRIDMET}, layer::Symbol; date=nothing) =
+    layer === :elev ? GRIDMET_ELEV_URI : joinpath(GRIDMET_URI, rastername(T, layer; date))
 
-function getraster(T::Type{GRIDMET}, layers::Union{Tuple,Symbol}; date)
+function getraster(T::Type{GRIDMET}, layers::Union{Tuple,Symbol}; date=nothing)
     _getraster(T, layers, date)
 end
 
@@ -90,11 +98,14 @@ end
 function _getraster(T::Type{GRIDMET}, layers, dates::AbstractArray)
     _getraster.(T, Ref(layers), dates)
 end
-function _getraster(T::Type{GRIDMET}, layers::Tuple, date::Dates.TimeType)
+function _getraster(T::Type{GRIDMET}, layers::Tuple, date::Union{Dates.TimeType,Nothing})
     _map_layers(T, layers, date)
 end
-function _getraster(T::Type{GRIDMET}, layer::Symbol, date::Dates.TimeType)
+function _getraster(T::Type{GRIDMET}, layer::Symbol, date::Union{Dates.TimeType,Nothing})
     _check_layer(T, layer)
+    if layer !== :elev && date === nothing
+        throw(ArgumentError("`date` keyword is required for GRIDMET layer `$layer`"))
+    end
     path = rasterpath(T, layer; date)
     url  = rasterurl(T, layer; date)
     _maybe_download(url, path)

--- a/src/gridmet/gridmet.jl
+++ b/src/gridmet/gridmet.jl
@@ -23,36 +23,40 @@ const GRIDMET_LAYERS = (
     spi  = (description="Standardized Precipitation Index",                       units="unitless"),
     spei = (description="Standardized Precipitation-Evapotranspiration Index",    units="unitless"),
     eddi = (description="Evaporative Demand Drought Index",                        units="unitless"),
-    elev = (description="Elevation",                                              units="m"),
 )
 
 @doc """
-    GRIDMET <: RasterDataSource
+    GRIDMET{X} <: RasterDataSource
 
 Data from the gridMET dataset (also known as METDATA), a high-resolution (~4 km)
 daily gridded surface meteorological dataset covering the contiguous United States.
 
 See: [climatologylab.org/gridmet](https://www.climatologylab.org/gridmet.html)
 
-Data are served as annual NetCDF files, one per variable per year. Each file
-contains daily layers for the full calendar year. Coverage is from 1979 to present.
+Two products are available:
+
+**Daily meteorology** — `GRIDMET` (default):
+Annual NetCDF files, one per variable per year, each containing daily layers for the
+full calendar year. Coverage is from 1979 to present.
 
 The available layers are: `$(keys(GRIDMET_LAYERS))`.
 
-`getraster` for `GRIDMET` requires a `date` keyword to specify the year to download,
-except for the static `elev` layer, which is a single unchanging file and ignores `date`.
+**Static elevation** — `GRIDMET{Elevation}`:
+A single NetCDF file giving the ~4 km elevation grid used by gridMET. No `date` keyword.
 
 # Usage with `getraster`
     getraster(source::Type{GRIDMET}, [layer]; date)
+    getraster(source::Type{GRIDMET{Elevation}}, [layer])
 
 # Arguments
-- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(keys(GRIDMET_LAYERS))`.
-    Without a `layer` argument all layers are downloaded and a `NamedTuple` of paths returned.
+- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(keys(GRIDMET_LAYERS))` for `GRIDMET`,
+    or `:elev` for `GRIDMET{Elevation}`. Without a `layer` argument all layers are
+    downloaded and a `NamedTuple` of paths returned.
 
 # Keywords
 - `date`: a `Date`, `AbstractVector` of `Date`, or a `Tuple` of start and end dates.
     Only the year component is used. For multiple dates, a `Vector` of paths is returned.
-    Not required when `layer` is `:elev`.
+    Applies only to `GRIDMET`, not `GRIDMET{Elevation}`.
 
 # Example
 ```julia
@@ -65,30 +69,31 @@ julia> getraster(GRIDMET, (:tmmx, :pr); date=Date(2020))
 julia> getraster(GRIDMET, :tmmx; date=(Date(2018), Date(2020)))
 [".../tmmx_2018.nc", ".../tmmx_2019.nc", ".../tmmx_2020.nc"]
 
-julia> getraster(GRIDMET, :elev)
+julia> getraster(GRIDMET{Elevation}, :elev)
 "/path/to/storage/GRIDMET/elev/metdata_elevationdata.nc"
 ```
 
 Returns the filepath/s of the downloaded or pre-existing files.
 """ GRIDMET
-struct GRIDMET <: RasterDataSource end
+struct GRIDMET{X} <: RasterDataSource end
+
+# --- Daily meteorology (bare GRIDMET) --------------------------------------
 
 layers(::Type{GRIDMET}) = keys(GRIDMET_LAYERS)
 date_step(::Type{GRIDMET}) = Year(1)
 date_range(::Type{GRIDMET}) = (Date(1979, 1, 1), Date(2025, 12, 31))
 getraster_keywords(::Type{GRIDMET}) = (:date,)
 
-rastername(::Type{GRIDMET}, layer::Symbol; date=nothing) =
-    layer === :elev ? "metdata_elevationdata.nc" : "$(layer)_$(year(date)).nc"
+rastername(::Type{GRIDMET}, layer::Symbol; date) = "$(layer)_$(year(date)).nc"
 
 rasterpath(::Type{GRIDMET}) = joinpath(rasterpath(), "GRIDMET")
-rasterpath(T::Type{GRIDMET}, layer::Symbol; date=nothing) =
+rasterpath(T::Type{GRIDMET}, layer::Symbol; date) =
     joinpath(rasterpath(T), string(layer), rastername(T, layer; date))
 
-rasterurl(T::Type{GRIDMET}, layer::Symbol; date=nothing) =
-    layer === :elev ? GRIDMET_ELEV_URI : joinpath(GRIDMET_URI, rastername(T, layer; date))
+rasterurl(T::Type{GRIDMET}, layer::Symbol; date) =
+    joinpath(GRIDMET_URI, rastername(T, layer; date))
 
-function getraster(T::Type{GRIDMET}, layers::Union{Tuple,Symbol}; date=nothing)
+function getraster(T::Type{GRIDMET}, layers::Union{Tuple,Symbol}; date)
     _getraster(T, layers, date)
 end
 
@@ -98,15 +103,31 @@ end
 function _getraster(T::Type{GRIDMET}, layers, dates::AbstractArray)
     _getraster.(T, Ref(layers), dates)
 end
-function _getraster(T::Type{GRIDMET}, layers::Tuple, date::Union{Dates.TimeType,Nothing})
+function _getraster(T::Type{GRIDMET}, layers::Tuple, date::Dates.TimeType)
     _map_layers(T, layers, date)
 end
-function _getraster(T::Type{GRIDMET}, layer::Symbol, date::Union{Dates.TimeType,Nothing})
+function _getraster(T::Type{GRIDMET}, layer::Symbol, date::Dates.TimeType)
     _check_layer(T, layer)
-    if layer !== :elev && date === nothing
-        throw(ArgumentError("`date` keyword is required for GRIDMET layer `$layer`"))
-    end
     path = rasterpath(T, layer; date)
     url  = rasterurl(T, layer; date)
     _maybe_download(url, path)
+end
+
+# --- Static elevation (GRIDMET{Elevation}) ---------------------------------
+
+layers(::Type{GRIDMET{Elevation}}) = (:elev,)
+getraster_keywords(::Type{GRIDMET{Elevation}}) = ()
+
+rastername(::Type{GRIDMET{Elevation}}, layer::Symbol) = "metdata_elevationdata.nc"
+rasterpath(T::Type{GRIDMET{Elevation}}, layer::Symbol) =
+    joinpath(rasterpath(GRIDMET), string(layer), rastername(T, layer))
+rasterurl(::Type{GRIDMET{Elevation}}, layer::Symbol) = GRIDMET_ELEV_URI
+
+getraster(T::Type{GRIDMET{Elevation}}, layers::Union{Tuple,Symbol}) =
+    _getraster(T, layers)
+
+_getraster(T::Type{GRIDMET{Elevation}}, layers::Tuple) = _map_layers(T, layers)
+function _getraster(T::Type{GRIDMET{Elevation}}, layer::Symbol)
+    _check_layer(T, layer)
+    _maybe_download(rasterurl(T, layer), rasterpath(T, layer))
 end

--- a/test/gridmet.jl
+++ b/test/gridmet.jl
@@ -8,27 +8,28 @@ using RasterDataSources: rastername, rasterurl, rasterpath
 
     @test rastername(GRIDMET, :tmmx; date=Date(2020, 6, 15)) == "tmmx_2020.nc"
     @test rastername(GRIDMET, :pr;   date=Date(1979, 1, 1))  == "pr_1979.nc"
-    @test rastername(GRIDMET, :elev) == "metdata_elevationdata.nc"
 
     @test rasterpath(GRIDMET, :tmmx; date=Date(2020, 6, 15)) ==
         joinpath(gridmet_path, "tmmx", "tmmx_2020.nc")
-    @test rasterpath(GRIDMET, :elev) ==
-        joinpath(gridmet_path, "elev", "metdata_elevationdata.nc")
 
     @test rasterurl(GRIDMET, :tmmx; date=Date(2020)) ==
         URI(scheme="https", host="www.northwestknowledge.net", path="/metdata/data/tmmx_2020.nc")
-    @test rasterurl(GRIDMET, :elev) ==
-        URI("http://thredds.northwestknowledge.net:8080/thredds/fileServer/MET/elev/metdata_elevationdata.nc")
 
     @test RasterDataSources.getraster_keywords(GRIDMET) == (:date,)
     @test RasterDataSources.layers(GRIDMET) == (
         :tmmx, :tmmn, :pr, :rmax, :rmin, :sph, :srad, :th, :vs, :etr, :pet,
-        :vpd, :erc, :bi, :fm1, :fm100, :pdsi, :z, :spi, :spei, :eddi, :elev,
+        :vpd, :erc, :bi, :fm1, :fm100, :pdsi, :z, :spi, :spei, :eddi,
     )
     @test RasterDataSources.date_step(GRIDMET) == Year(1)
 
-    # date is required for dated layers, but not for :elev
-    @test_throws ArgumentError getraster(GRIDMET, :tmmx)
+    # Static elevation is a separate parametric type
+    @test RasterDataSources.layers(GRIDMET{Elevation}) == (:elev,)
+    @test RasterDataSources.getraster_keywords(GRIDMET{Elevation}) == ()
+    @test rastername(GRIDMET{Elevation}, :elev) == "metdata_elevationdata.nc"
+    @test rasterpath(GRIDMET{Elevation}, :elev) ==
+        joinpath(gridmet_path, "elev", "metdata_elevationdata.nc")
+    @test rasterurl(GRIDMET{Elevation}, :elev) ==
+        URI("http://thredds.northwestknowledge.net:8080/thredds/fileServer/MET/elev/metdata_elevationdata.nc")
 
     if !Sys.iswindows()
         # Test actual download
@@ -48,7 +49,7 @@ using RasterDataSources: rastername, rasterurl, rasterpath
 
         # Static elevation layer, no date required
         raster_path_elev = joinpath(gridmet_path, "elev", "metdata_elevationdata.nc")
-        @test getraster(GRIDMET, :elev) == raster_path_elev
+        @test getraster(GRIDMET{Elevation}, :elev) == raster_path_elev
         @test isfile(raster_path_elev)
     end
 end

--- a/test/gridmet.jl
+++ b/test/gridmet.jl
@@ -8,19 +8,27 @@ using RasterDataSources: rastername, rasterurl, rasterpath
 
     @test rastername(GRIDMET, :tmmx; date=Date(2020, 6, 15)) == "tmmx_2020.nc"
     @test rastername(GRIDMET, :pr;   date=Date(1979, 1, 1))  == "pr_1979.nc"
+    @test rastername(GRIDMET, :elev) == "metdata_elevationdata.nc"
 
     @test rasterpath(GRIDMET, :tmmx; date=Date(2020, 6, 15)) ==
         joinpath(gridmet_path, "tmmx", "tmmx_2020.nc")
+    @test rasterpath(GRIDMET, :elev) ==
+        joinpath(gridmet_path, "elev", "metdata_elevationdata.nc")
 
     @test rasterurl(GRIDMET, :tmmx; date=Date(2020)) ==
         URI(scheme="https", host="www.northwestknowledge.net", path="/metdata/data/tmmx_2020.nc")
+    @test rasterurl(GRIDMET, :elev) ==
+        URI("http://thredds.northwestknowledge.net:8080/thredds/fileServer/MET/elev/metdata_elevationdata.nc")
 
     @test RasterDataSources.getraster_keywords(GRIDMET) == (:date,)
     @test RasterDataSources.layers(GRIDMET) == (
         :tmmx, :tmmn, :pr, :rmax, :rmin, :sph, :srad, :th, :vs, :etr, :pet,
-        :vpd, :erc, :bi, :fm1, :fm100, :pdsi, :z, :spi, :spei, :eddi,
+        :vpd, :erc, :bi, :fm1, :fm100, :pdsi, :z, :spi, :spei, :eddi, :elev,
     )
     @test RasterDataSources.date_step(GRIDMET) == Year(1)
+
+    # date is required for dated layers, but not for :elev
+    @test_throws ArgumentError getraster(GRIDMET, :tmmx)
 
     if !Sys.iswindows()
         # Test actual download
@@ -37,5 +45,10 @@ using RasterDataSources: rastername, rasterurl, rasterpath
         # Tuple of dates expands across the year range
         @test getraster(GRIDMET, :tmmx; date=(Date(2019), Date(2020))) ==
             [joinpath(gridmet_path, "tmmx", "tmmx_2019.nc"), raster_path]
+
+        # Static elevation layer, no date required
+        raster_path_elev = joinpath(gridmet_path, "elev", "metdata_elevationdata.nc")
+        @test getraster(GRIDMET, :elev) == raster_path_elev
+        @test isfile(raster_path_elev)
     end
 end


### PR DESCRIPTION
adds gridMET's elevation layer, needed as a reference for making lapse-rate corrections