### PR TITLE
add silo dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently sources include:
 | GADS         | https://zenodo.org/records/19246341      | Spectral aerosol optical depths          |
 | CRUCL2       | https://zenodo.org/records/20754689      | Monthly mean climate 1961–1990           |
 | CPCSoil      | https://psl.noaa.gov/data/gridded/data.cpcsoil.html | LTM climatology and historical monthly means |
+| SILO         | https://www.longpaddock.qld.gov.au/silo/about/overview/ | Complete                          |
 
 Please open an issue if you need more datasets added, or (even better) open a pull request 
 following the form of the other datasets where possible.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -94,6 +94,12 @@ SRTM
 ```@docs
 SLGA
 ```
+
+## SILO
+
+```@docs
+SILO
+```
 ## GADS
 
 ```@docs

--- a/src/RasterDataSources.jl
+++ b/src/RasterDataSources.jl
@@ -15,7 +15,7 @@ using Dates,
 
 import JSON
 
-export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM, CopernicusDEM, MODIS, ERA5, NCEP, TerraClimate, GRIDMET, SLGA, CRUCL2, CPCSoil, GADS
+export WorldClim, CHELSA, EarthEnv, AWAP, ALWB, SRTM, CopernicusDEM, MODIS, ERA5, NCEP, TerraClimate, GRIDMET, SLGA, CRUCL2, CPCSoil, GADS, SILO
 
 export BioClim, BioClimPlus, Climate, Weather, Elevation, LandCover, HabitatHeterogeneity, CoarseFragments, Mean
 
@@ -85,6 +85,8 @@ include("modis/examples.jl")
 include("ncep/ncep.jl")
 
 include("gridmet/gridmet.jl")
+
+include("silo/silo.jl")
 
 include("slga/slga.jl")
 include("slga/coarsefragments.jl")

--- a/src/shared.jl
+++ b/src/shared.jl
@@ -11,6 +11,9 @@ getraster(T::Type; kw...) = getraster(T, layers(T); kw...)
 Trait for defining data source keywords, which returns
 a `NTuple{N,Symbol}`.
 
+Only lists the source-specific keywords. `update`, which is accepted by every
+`getraster` method, is not included.
+
 The default fallback method returns `()`.
 """
 getraster_keywords(::Type{<:RasterDataSource}) = ()
@@ -58,8 +61,8 @@ function _date_error(date, daterange)
     error("The requested dataset covers the period from $startyear-$endyear, which does not include $date")
 end         
 
-function _maybe_download(uri::URI, filepath, headers = [])
-    if !isfile(filepath)
+function _maybe_download(uri::URI, filepath, headers = []; update::Bool=false)
+    if update || !isfile(filepath)
         mkpath(dirname(filepath))
         @info "Starting download for $uri"
         try

--- a/src/silo/silo.jl
+++ b/src/silo/silo.jl
@@ -1,0 +1,110 @@
+const SILO_URI = URI(scheme="https", host="s3-ap-southeast-2.amazonaws.com", path="/silo-open-data/Official/annual")
+
+const SILO_LAYERS = (
+    daily_rain          = (description="Daily rainfall",                                                          units="mm"),
+    et_morton_actual    = (description="Morton's areal actual evapotranspiration",                                units="mm"),
+    et_morton_potential = (description="Morton's point potential evapotranspiration",                             units="mm"),
+    et_morton_wet       = (description="Morton's wet-environment areal potential evapotranspiration over land",   units="mm"),
+    et_short_crop       = (description="FAO56 short crop",                                                        units="mm"),
+    et_tall_crop        = (description="ASCE tall crop",                                                         units="mm"),
+    evap_morton_lake    = (description="Morton's shallow lake evaporation",                                      units="mm"),
+    evap_pan            = (description="Class A pan evaporation",                                                units="mm"),
+    evap_syn            = (description="Synthetic estimate",                                                     units="mm"),
+    max_temp            = (description="Maximum temperature",                                                    units="°C"),
+    min_temp            = (description="Minimum temperature",                                                    units="°C"),
+    monthly_rain        = (description="Monthly rainfall",                                                       units="mm"),
+    mslp                = (description="Mean sea level pressure",                                                units="hPa"),
+    radiation           = (description="Solar exposure, consisting of both direct and diffuse components",       units="MJ/m^2"),
+    rh_tmax             = (description="Relative humidity at the time of maximum temperature",                   units="%"),
+    rh_tmin             = (description="Relative humidity at the time of minimum temperature",                   units="%"),
+    vp                  = (description="Vapour pressure",                                                        units="hPa"),
+    vp_deficit          = (description="Vapour pressure deficit",                                                units="hPa"),
+)
+
+# Some variables have shorter coverage than the general 1889-present range.
+const SILO_MIN_YEAR = (mslp=1957, evap_pan=1970)
+_silo_min_year(layer::Symbol) = get(SILO_MIN_YEAR, layer, 1889)
+
+@doc """
+    SILO <: RasterDataSource
+
+Data from the SILO (Scientific Information for Land Owners) gridded climate
+datasets for Australia, at approximately 5 km resolution.
+
+See: [longpaddock.qld.gov.au/silo](https://www.longpaddock.qld.gov.au/silo/about/overview/)
+
+Data are served as annual NetCDF files, one per variable per year, hosted on
+AWS S3 under the AWS Public Data Program. Each file contains daily grids for
+the full calendar year, except `monthly_rain` which contains 12 monthly grids.
+Coverage is from 1889 to present for most variables, 1957 for `mslp`, and
+1970 for `evap_pan`.
+
+# Usage with `getraster`
+    getraster(source::Type{SILO}, [layer]; date)
+
+# Arguments
+- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(keys(SILO_LAYERS))`.
+    Without a `layer` argument all layers are downloaded and a `NamedTuple` of paths returned.
+
+# Keywords
+- `date`: a `Date`, `AbstractVector` of `Date`, or a `Tuple` of start and end dates.
+    Only the year component is used. For multiple dates, a `Vector` of paths is returned.
+
+# Example
+```julia
+julia> getraster(SILO, :daily_rain; date=Date(2020))
+"/path/to/storage/SILO/daily_rain/2020.daily_rain.nc"
+
+julia> getraster(SILO, (:daily_rain, :max_temp); date=Date(2020))
+(daily_rain="/path/.../2020.daily_rain.nc", max_temp="/path/.../2020.max_temp.nc")
+
+julia> getraster(SILO, :daily_rain; date=(Date(2018), Date(2020)))
+[".../2018.daily_rain.nc", ".../2019.daily_rain.nc", ".../2020.daily_rain.nc"]
+```
+
+Returns the filepath/s of the downloaded or pre-existing files.
+
+!!! note
+    `getraster` never re-downloads an existing local file, so the current
+    year's data will go stale as SILO updates it. Delete the local file to
+    force a refresh.
+""" SILO
+struct SILO <: RasterDataSource end
+
+layers(::Type{SILO}) = keys(SILO_LAYERS)
+date_step(::Type{SILO}) = Year(1)
+date_range(::Type{SILO}) = (Date(1889, 1, 1), Date(year(today()), 12, 31))
+getraster_keywords(::Type{SILO}) = (:date,)
+
+rastername(::Type{SILO}, layer::Symbol; date) = "$(year(date)).$(layer).nc"
+
+rasterpath(::Type{SILO}) = joinpath(rasterpath(), "SILO")
+rasterpath(T::Type{SILO}, layer::Symbol; date) =
+    joinpath(rasterpath(T), string(layer), rastername(T, layer; date))
+
+rasterurl(T::Type{SILO}, layer::Symbol; date) =
+    joinpath(SILO_URI, string(layer), rastername(T, layer; date))
+
+function getraster(T::Type{SILO}, layers::Union{Tuple,Symbol}; date)
+    _getraster(T, layers, date)
+end
+
+function _getraster(T::Type{SILO}, layers, dates::Tuple{<:Any,<:Any})
+    _getraster(T, layers, date_sequence(T, dates))
+end
+function _getraster(T::Type{SILO}, layers, dates::AbstractArray)
+    _getraster.(T, Ref(layers), dates)
+end
+function _getraster(T::Type{SILO}, layers::Tuple, date::Dates.TimeType)
+    _map_layers(T, layers, date)
+end
+function _getraster(T::Type{SILO}, layer::Symbol, date::Dates.TimeType)
+    _check_layer(T, layer)
+    minyear = _silo_min_year(layer)
+    year(date) >= minyear || throw(ArgumentError(
+        "SILO layer `$layer` is only available from $minyear, got $(year(date))"
+    ))
+    path = rasterpath(T, layer; date)
+    url  = rasterurl(T, layer; date)
+    _maybe_download(url, path)
+end

--- a/src/silo/silo.jl
+++ b/src/silo/silo.jl
@@ -49,6 +49,8 @@ Coverage is from 1889 to present for most variables, 1957 for `mslp`, and
 # Keywords
 - `date`: a `Date`, `AbstractVector` of `Date`, or a `Tuple` of start and end dates.
     Only the year component is used. For multiple dates, a `Vector` of paths is returned.
+- `update`: `Bool`, defaults to `false`. If `true`, re-download files even when a local
+    copy already exists. Useful for the current year, which SILO updates in place.
 
 # Example
 ```julia
@@ -65,9 +67,9 @@ julia> getraster(SILO, :daily_rain; date=(Date(2018), Date(2020)))
 Returns the filepath/s of the downloaded or pre-existing files.
 
 !!! note
-    `getraster` never re-downloads an existing local file, so the current
-    year's data will go stale as SILO updates it. Delete the local file to
-    force a refresh.
+    By default `getraster` will not re-download an existing local file, so the
+    current year's data will go stale as SILO updates it. Pass `update=true`
+    to force a refresh.
 """ SILO
 struct SILO <: RasterDataSource end
 
@@ -85,20 +87,20 @@ rasterpath(T::Type{SILO}, layer::Symbol; date) =
 rasterurl(T::Type{SILO}, layer::Symbol; date) =
     joinpath(SILO_URI, string(layer), rastername(T, layer; date))
 
-function getraster(T::Type{SILO}, layers::Union{Tuple,Symbol}; date)
-    _getraster(T, layers, date)
+function getraster(T::Type{SILO}, layers::Union{Tuple,Symbol}; date, update::Bool=false)
+    _getraster(T, layers, date; update)
 end
 
-function _getraster(T::Type{SILO}, layers, dates::Tuple{<:Any,<:Any})
-    _getraster(T, layers, date_sequence(T, dates))
+function _getraster(T::Type{SILO}, layers, dates::Tuple{<:Any,<:Any}; update::Bool=false)
+    _getraster(T, layers, date_sequence(T, dates); update)
 end
-function _getraster(T::Type{SILO}, layers, dates::AbstractArray)
-    _getraster.(T, Ref(layers), dates)
+function _getraster(T::Type{SILO}, layers, dates::AbstractArray; update::Bool=false)
+    map(d -> _getraster(T, layers, d; update), dates)
 end
-function _getraster(T::Type{SILO}, layers::Tuple, date::Dates.TimeType)
-    _map_layers(T, layers, date)
+function _getraster(T::Type{SILO}, layers::Tuple, date::Dates.TimeType; update::Bool=false)
+    _map_layers(T, layers, date; update)
 end
-function _getraster(T::Type{SILO}, layer::Symbol, date::Dates.TimeType)
+function _getraster(T::Type{SILO}, layer::Symbol, date::Dates.TimeType; update::Bool=false)
     _check_layer(T, layer)
     minyear = _silo_min_year(layer)
     year(date) >= minyear || throw(ArgumentError(
@@ -106,5 +108,5 @@ function _getraster(T::Type{SILO}, layer::Symbol, date::Dates.TimeType)
     ))
     path = rasterpath(T, layer; date)
     url  = rasterurl(T, layer; date)
-    _maybe_download(url, path)
+    _maybe_download(url, path; update)
 end

--- a/src/silo/silo.jl
+++ b/src/silo/silo.jl
@@ -1,24 +1,10 @@
 const SILO_URI = URI(scheme="https", host="s3-ap-southeast-2.amazonaws.com", path="/silo-open-data/Official/annual")
 
 const SILO_LAYERS = (
-    daily_rain          = (description="Daily rainfall",                                                          units="mm"),
-    et_morton_actual    = (description="Morton's areal actual evapotranspiration",                                units="mm"),
-    et_morton_potential = (description="Morton's point potential evapotranspiration",                             units="mm"),
-    et_morton_wet       = (description="Morton's wet-environment areal potential evapotranspiration over land",   units="mm"),
-    et_short_crop       = (description="FAO56 short crop",                                                        units="mm"),
-    et_tall_crop        = (description="ASCE tall crop",                                                         units="mm"),
-    evap_morton_lake    = (description="Morton's shallow lake evaporation",                                      units="mm"),
-    evap_pan            = (description="Class A pan evaporation",                                                units="mm"),
-    evap_syn            = (description="Synthetic estimate",                                                     units="mm"),
-    max_temp            = (description="Maximum temperature",                                                    units="°C"),
-    min_temp            = (description="Minimum temperature",                                                    units="°C"),
-    monthly_rain        = (description="Monthly rainfall",                                                       units="mm"),
-    mslp                = (description="Mean sea level pressure",                                                units="hPa"),
-    radiation           = (description="Solar exposure, consisting of both direct and diffuse components",       units="MJ/m^2"),
-    rh_tmax             = (description="Relative humidity at the time of maximum temperature",                   units="%"),
-    rh_tmin             = (description="Relative humidity at the time of minimum temperature",                   units="%"),
-    vp                  = (description="Vapour pressure",                                                        units="hPa"),
-    vp_deficit          = (description="Vapour pressure deficit",                                                units="hPa"),
+    :daily_rain, :et_morton_actual, :et_morton_potential, :et_morton_wet,
+    :et_short_crop, :et_tall_crop, :evap_morton_lake, :evap_pan, :evap_syn,
+    :max_temp, :min_temp, :monthly_rain, :mslp, :radiation,
+    :rh_tmax, :rh_tmin, :vp, :vp_deficit,
 )
 
 # Some variables have shorter coverage than the general 1889-present range.
@@ -43,7 +29,7 @@ Coverage is from 1889 to present for most variables, 1957 for `mslp`, and
     getraster(source::Type{SILO}, [layer]; date)
 
 # Arguments
-- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(keys(SILO_LAYERS))`.
+- `layer`: `Symbol` or `Tuple` of `Symbol` from `$(SILO_LAYERS)`.
     Without a `layer` argument all layers are downloaded and a `NamedTuple` of paths returned.
 
 # Keywords
@@ -73,7 +59,7 @@ Returns the filepath/s of the downloaded or pre-existing files.
 """ SILO
 struct SILO <: RasterDataSource end
 
-layers(::Type{SILO}) = keys(SILO_LAYERS)
+layers(::Type{SILO}) = SILO_LAYERS
 date_step(::Type{SILO}) = Year(1)
 date_range(::Type{SILO}) = (Date(1889, 1, 1), Date(year(today()), 12, 31))
 getraster_keywords(::Type{SILO}) = (:date,)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ using SafeTestsets, Aqua, RasterDataSources, Pkg, Dates
 @time @safetestset "era5" begin include("era5.jl") end
 @time @safetestset "terraclimate" begin include("terraclimate.jl") end
 @time @safetestset "gridmet" begin include("gridmet.jl") end
+@time @safetestset "silo" begin include("silo.jl") end
 @time @safetestset "chelsa bioclim" begin include("chelsa-bioclim.jl") end
 @time @safetestset "chelsa climate" begin include("chelsa-climate.jl") end
 @time @safetestset "chelsa future" begin include("chelsa-future.jl") end

--- a/test/silo.jl
+++ b/test/silo.jl
@@ -1,0 +1,41 @@
+using RasterDataSources, URIs, Test, Dates
+using RasterDataSources: rastername, rasterurl, rasterpath
+
+@testset "SILO" begin
+
+    silo_path = joinpath(ENV["RASTERDATASOURCES_PATH"], "SILO")
+    @test rasterpath(SILO) == silo_path
+
+    @test rastername(SILO, :daily_rain; date=Date(2020, 6, 15)) == "2020.daily_rain.nc"
+    @test rastername(SILO, :max_temp;  date=Date(1979, 1, 1))  == "1979.max_temp.nc"
+
+    @test rasterpath(SILO, :daily_rain; date=Date(2020, 6, 15)) ==
+        joinpath(silo_path, "daily_rain", "2020.daily_rain.nc")
+
+    @test rasterurl(SILO, :daily_rain; date=Date(2020)) ==
+        URI(scheme="https", host="s3-ap-southeast-2.amazonaws.com",
+            path="/silo-open-data/Official/annual/daily_rain/2020.daily_rain.nc")
+
+    @test RasterDataSources.getraster_keywords(SILO) == (:date,)
+    @test RasterDataSources.layers(SILO) == (
+        :daily_rain, :et_morton_actual, :et_morton_potential,
+        :et_morton_wet, :et_short_crop, :et_tall_crop, :evap_morton_lake, :evap_pan,
+        :evap_syn, :max_temp, :min_temp, :monthly_rain, :mslp, :radiation, :rh_tmax,
+        :rh_tmin, :vp, :vp_deficit,
+    )
+    @test RasterDataSources.date_step(SILO) == Year(1)
+
+    @testset "shorter-coverage variables reject dates before their start year" begin
+        @test_throws ArgumentError getraster(SILO, :mslp; date=Date(1950))
+        @test_throws ArgumentError getraster(SILO, :evap_pan; date=Date(1965))
+    end
+
+    if !Sys.iswindows()
+        # monthly_rain is ~14 MB, small enough to actually download in CI.
+        # The other layers are annual files of daily data (~400 MB each), so
+        # only path/name/url construction is tested for those, above.
+        raster_path = joinpath(silo_path, "monthly_rain", "2020.monthly_rain.nc")
+        @test getraster(SILO, :monthly_rain; date=Date(2020, 1, 1)) == raster_path
+        @test isfile(raster_path)
+    end
+end


### PR DESCRIPTION
Adds an Australian daily weather data product - note this is a dataset that is available up to "now" so I put a note in for users that they need to delete the current year's data if they want to update this year's data - this would be an issue for some of the other datasets.